### PR TITLE
Fix #286 Prompt applicants to update their application

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ The factory will fill in random names, phrases, and choices for any required fie
 In the example code below, we'll create a new CoordinatorApproval object. The factories code automatically sets all passwords for User accounts to `test`. We'll set the CoordinatorApproval approval status to approved (by default, all ApprovalStatus objects are created with the withdrawn approval status). The example sets the community name to "Really Awesome Community", but you can use the name of your favorite FOSS community instead.
 
 ```
+from home.factories import CoordinatorApprovalFactory
+from home.models import ApprovalStatus
+from django.utils.text import slugify
 >>> name = "Really Awesome Community"
 >>> coord1 = CoordinatorApprovalFactory(
 	coordinator__account__username="coord1",

--- a/home/templates/home/snippet/eligibility_prompts.html
+++ b/home/templates/home/snippet/eligibility_prompts.html
@@ -4,6 +4,8 @@
 
 {% if role.needs_application %}
 {% include "home/snippet/eligibility_prompt.html" %}
+{% elif role.application.barrierstoparticipation.applicant_should_update %}
+{% include "home/snippet/pending_prompt.html" %}
 {% elif role.application.is_rejected %}
 {% include "home/snippet/ineligible_prompt.html" %}
 {% elif role.application.is_pending %}


### PR DESCRIPTION
Updates applicant dashboard.

This also starts updating the README to include `imports` in the code snippets.