### PR TITLE
Add quotes around the public email to avoid splitting commas in the name

### DIFF
--- a/home/templates/home/community_read_only.html
+++ b/home/templates/home/community_read_only.html
@@ -39,7 +39,7 @@ Past community participation in Outreachy
 {% if approved_coordinator_list %}
 	<p>The {{ community.name }} coordinator{{ approved_coordinator_list|length|pluralize:" is,s are" }}
 	{% for approval in approved_coordinator_list %}
-	{% if user.is_authenticated %}<a href="{{ approval.get_preview_url }}">{{ approval.coordinator.public_name }}</a>{% else %}{{ approval.coordinator.public_name }}{% endif %}{% if user.is_authenticated %} &lt;{{ approval.coordinator.account.email }}&gt;{% endif %}{% if not forloop.last %}, {% else %}.{% endif %}
+	{% if user.is_authenticated %}<a href="{{ approval.get_preview_url }}">{{ approval.coordinator.public_name }}</a>{% else %}"{{ approval.coordinator.public_name }}"{% endif %}{% if user.is_authenticated %} &lt;{{ approval.coordinator.account.email }}&gt;{% endif %}{% if not forloop.last %}, {% else %}.{% endif %}
 	{% endfor %}
 {% else %}
 	<p>This community currently has no approved coordinator. Coordinators approve mentored projects, and communicate with both mentors and Outreachy organizers. The full list of coordinator duties can be found on <a href="/mentor/">here</a>.
@@ -236,9 +236,11 @@ Past community participation in Outreachy
 		</p>
 		<p class="card-text">
 		{% for approval in approved_coordinator_list %}
-			- {{ approval.coordinator.public_name }}
 			{% if user.is_authenticated %}
+			- "{{ approval.coordinator.public_name }}"
 				&lt;{{ approval.coordinator.account.email }}&gt;
+			{% else %}
+			- {{ approval.coordinator.public_name }}
 			{% endif %}
 			{% if not forloop.last %}<br />{% endif %}
 		{% endfor %}

--- a/home/templates/home/preview/coordinatorapproval.html
+++ b/home/templates/home/preview/coordinatorapproval.html
@@ -15,7 +15,7 @@
 
 {% with c=coordinatorapproval.coordinator community=coordinatorapproval.community %}
 
-<p>{{ c.public_name }} &lt;{{ c.account.email }}&gt;</p>
+<p>"{{ c.public_name }}" &lt;{{ c.account.email }}&gt;</p>
 
 {% if coordinatorapproval.approval_status == coordinatorapproval.PENDING %}
 {% if coordinatorapproval|is_approver:request.user %}

--- a/home/templates/home/preview/coordinatorapproval_action.html
+++ b/home/templates/home/preview/coordinatorapproval_action.html
@@ -27,7 +27,7 @@ Sign Up to Coordinate for {{ coordinatorapproval.community }}
 {% with c=coordinatorapproval.coordinator community=coordinatorapproval.community %}
 
 {% if view.kwargs.action != 'submit' %}
-	<p>{{ c.public_name }} &lt;{{ c.account.email }}&gt;</p>
+	<p>"{{ c.public_name }}" &lt;{{ c.account.email }}&gt;</p>
 
 	<ul>
 		{% if c.pronouns_to_participants %}<li>Pronouns: {{ c.get_pronouns_display }}</li>{% endif %}

--- a/home/templates/home/preview/finalapplication_action.html
+++ b/home/templates/home/preview/finalapplication_action.html
@@ -21,7 +21,7 @@
 {% elif view.kwargs.action == 'withdraw' %}
 <p>We're sorry to hear you want to withdraw your application. We hope that working with Outreachy mentors and coordinators has been a good experience for you, and please <a href="{% url 'contact-us' %}">contact the Outreachy organizers</a> if you have any concerns.</p>
 {% else %}
-	<p>{{ applicant.public_name }} &lt;{{ applicant.account.email }}&gt;</p>
+	<p>"{{ applicant.public_name }}" &lt;{{ applicant.account.email }}&gt;</p>
 	{% include "home/snippet/mentor_info.html" with approval=mentorapproval only %}
 {% endif %}
 

--- a/home/templates/home/preview/mentorapproval_action.html
+++ b/home/templates/home/preview/mentorapproval_action.html
@@ -38,20 +38,20 @@
 	<h1>Confirm Mentor</h1>
 
 	<p>Project: <a href="{{ project.get_preview_url }}">{{ project.short_title }}</a></p>
-	<p>{{ mentor.public_name }} &lt;{{ mentor.account.email }}&gt;</p>
+	<p>"{{ mentor.public_name }}" &lt;{{ mentor.account.email }}&gt;</p>
 
 {% elif view.kwargs.action == 'reject' %}
 	<h1>Reject Mentor</h1>
 
 	<p>Project: <a href="{{ project.get_preview_url }}">{{ project.short_title }}</a></p>
-	<p>{{ mentor.public_name }} &lt;{{ mentor.account.email }}&gt;</p>
+	<p>"{{ mentor.public_name }}" &lt;{{ mentor.account.email }}&gt;</p>
 
 {% else %}
 	<h1>Mentor Profile</h1>
 
 	<p>Project: <a href="{{ project.get_preview_url }}">{{ project.short_title }}</a></p>
 
-	<p>{{ mentor.public_name }} &lt;{{ mentor.account.email }}&gt;</p>
+	<p>"{{ mentor.public_name }}" &lt;{{ mentor.account.email }}&gt;</p>
 	{% include "home/snippet/mentor_info.html" with approval=mentorapproval only %}
 {% endif %}
 

--- a/home/templates/home/project_applicants.html
+++ b/home/templates/home/project_applicants.html
@@ -63,7 +63,7 @@ that timeline, taking into account any time commitments the applicant has.
 							</div>
 						</div>
 					</td>{% endif %}
-					<td>{{ fa.applicant.applicant.public_name }} &lt;{{ fa.applicant.applicant.account.email }}&gt; </td>
+					<td>"{{ fa.applicant.applicant.public_name }}" &lt;{{ fa.applicant.applicant.account.email }}&gt; </td>
 					<td><a href="#{{ fa.applicant.applicant.pk }}">(details)</a></td>
 					<td>
 						{% with selection=fa.get_intern_selection %}
@@ -175,7 +175,7 @@ that timeline, taking into account any time commitments the applicant has.
 		
 		<p>Contact Information:</p>
 		<ul>
-			<li>{{ applicant.public_name }} &lt;{{ applicant.account.email }}&gt;</li>
+			<li>"{{ applicant.public_name }}" &lt;{{ applicant.account.email }}&gt;</li>
 			{% if applicant.nick %}<li>Forum, chat, or IRC username: {{ applicant.nick }}</li>{% endif %}
 			{% if applicant.github_url %}<li>GitHub profile: <a href="{{ applicant.github_url }}">{{ applicant.github_url }}</a></li>{% endif %}
 			{% if applicant.gitlab_url %}<li>GitLab profile: <a href="{{ applicant.gitlab_url }}">{{ applicant.gitlab_url }}</a></li>{% endif %}

--- a/home/templates/home/project_read_only.html
+++ b/home/templates/home/project_read_only.html
@@ -146,7 +146,7 @@
 	{% if unapproved_mentors %}
 		<h3>Approve Mentors</h3>
 		{% for approval in unapproved_mentors %}
-			<p>{{ approval.mentor.public_name }} &lt;{{ approval.mentor.account.email }}&gt;</p>
+			<p>"{{ approval.mentor.public_name }}" &lt;{{ approval.mentor.account.email }}&gt;</p>
 			{% include "home/snippet/mentor_approval_warnings.html" %}
 			{% if approval.approval_status != approval.APPROVED %}
 			<a href="{{ approval.get_approve_url }}" class="btn btn-success">Approve Mentor</a>
@@ -161,7 +161,7 @@
 	{% if approved_mentors %}
 		<h3>Review Approved Mentors</h3>
 		{% for approval in approved_mentors %}
-			<p>{{ approval.mentor.public_name }} &lt;{{ approval.mentor.account.email }}&gt;</p>
+			<p>"{{ approval.mentor.public_name }}" &lt;{{ approval.mentor.account.email }}&gt;</p>
 			{% include "home/snippet/mentor_approval_warnings.html" %}
 			<a href="{{ approval.get_reject_url }}" class="btn btn-warning">Reject Mentor</a>
 			{% include "home/snippet/mentor_info.html" %}

--- a/home/templates/home/snippet/application_review_rows.html
+++ b/home/templates/home/snippet/application_review_rows.html
@@ -7,7 +7,7 @@
 		{% else %}<p> - </p>
 		{% endif %}
 	</td>
-	<td>{{ app.applicant.public_name }} &lt;{{ app.applicant.account.email }}&gt;</td>
+	<td>"{{ app.applicant.public_name }}" &lt;{{ app.applicant.account.email }}&gt;</td>
 	<td>
 		{% for essay_rating in app.get_essay_ratings %}
 			<p>{% include 'home/snippet/essay_rating.html' %}</p>

--- a/home/templates/home/snippet/mentor_info.html
+++ b/home/templates/home/snippet/mentor_info.html
@@ -1,6 +1,6 @@
 <h2>Mentor Personal Information</h2>
 <ul>
-	<li>Name: {{ approval.mentor.public_name }} &lt;{{ approval.mentor.account.email }}&gt;</li>
+	<li>Name: "{{ approval.mentor.public_name }}" &lt;{{ approval.mentor.account.email }}&gt;</li>
 	{% if approval.mentor.pronouns_to_participants %}<li>Pronouns: {{ approval.mentor.get_pronouns_html|safe }}</li>{% endif %}
 	{% if approval.mentor.timezone %}<li>Timezone: {{ approval.mentor.get_timezone_display }}</li>{% endif %}
 	{% if approval.mentor.primary_language %}<li>Primary language: {{ approval.mentor.get_primary_language_display }}</li>{% endif %}

--- a/home/templates/home/snippet/mentor_info_for_landing.html
+++ b/home/templates/home/snippet/mentor_info_for_landing.html
@@ -13,7 +13,7 @@
 {% endif %}
 <p>Contact info:</p>
 <ul>
-	<li>Personal email: {{ approval.mentor.public_name }} &lt;{{ approval.mentor.account.email }}&gt;</li>
+	<li>Personal email: "{{ approval.mentor.public_name }}" &lt;{{ approval.mentor.account.email }}&gt;</li>
 	{% if approval.mentor.nick %}
 		<li>Please try to contact the mentor on public community channels as much as possible. Often other mentors for the project can answer your question or point you in the right direction to get help. They may be able to answer your question faster than emailing your mentor directly. While it's fine to contact mentors privately with doubts, Outreachy applicants and interns will need to learn how to ask questions and work publicly through the community communication channels.</li>
 		<li>Username on community forums or chat: {{ approval.mentor.nick }}</li>

--- a/home/templates/home/snippet/project_landing_snippet.html
+++ b/home/templates/home/snippet/project_landing_snippet.html
@@ -153,7 +153,7 @@ to the community's coordinator. Each FOSS community has one or more coordinators
 {% if approved_coordinator_list %}
 The {{ community.name }} coordinator{{ approved_coordinator_list|length|pluralize:" is,(s) are" }} 
 	{% for approval in approved_coordinator_list %}
-		{{ approval.coordinator.public_name }}
+		"{{ approval.coordinator.public_name }}"
 		{% if user.is_authenticated %}
 			&lt;{{ approval.coordinator.account.email }}&gt;
 		{% endif %}


### PR DESCRIPTION
Fixes #307