### PR TITLE
Add a test for sending emails when interns conflict

### DIFF
--- a/home/test_email.py
+++ b/home/test_email.py
@@ -1,0 +1,28 @@
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from home import email as module
+from home import factories
+from home.models import InternSelection
+
+
+class EmailTests(TestCase):
+
+    @patch.object(module, 'send_group_template_mail')
+    def test_intern_selection_conflict_notification(self, mock_send_email):
+        project_a = factories.ProjectFactory()
+        intern_selection_project_a = factories.InternSelectionFactory(
+            project=project_a,
+            active=True
+        )
+        project_b = factories.ProjectFactory(project_round=project_a.project_round)
+        intern_selection_project_b = factories.InternSelectionFactory(
+            project=project_b,
+            applicant=intern_selection_project_a.applicant,
+            round=intern_selection_project_a.round(),
+            active=True,
+        )
+
+        module.intern_selection_conflict_notification(intern_selection_project_b, Mock())
+        mock_send_email.called == True


### PR DESCRIPTION
I added a test for the email functionality for the bug in issue 302.  This won't close or fix the issue but it should increase test coverage.

I have a hunch that this could be a problem with transaction/sessions.  i.e. If two separate users are creating an InternSelection object at the same time it could be that the transaction is not committed yet and thus not queriable yet from another session, but diagnosing this would require looking through the logs or simulating 2 users simultaneously creating and intern a selection. 

In any case hopefully this test helps :)