### PR TITLE
Past Rounds and Project Selection pages

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -225,7 +225,7 @@ class RoundPage(Page):
 
     def has_application_deadline_passed(self):
         return has_deadline_passed(self.appslate)
-    
+
     def InternSelectionDeadline(self):
         return(self.mentor_intern_selection_deadline)
 
@@ -246,7 +246,7 @@ class RoundPage(Page):
 
     def intern_sfc_initial_payment_notification_deadline(self):
         return(self.initialfeedback)
-    
+
     def initial_stipend_payment_deadline(self):
         return self.initialfeedback + datetime.timedelta(days=30)
 
@@ -327,6 +327,10 @@ class RoundPage(Page):
     def get_approved_communities(self):
         approved_participations = Participation.objects.filter(participating_round=self, approval_status=Participation.APPROVED).order_by('community__name')
         return [p.community for p in approved_participations]
+
+    def get_approved_communities_and_projects(self):
+        approved_participations = Participation.objects.filter(participating_round=self, approval_status=Participation.APPROVED).order_by('community__name')
+        return [(p.community, p.project_set.approved()) for p in approved_participations]
 
     def number_approved_communities_with_projects(self):
         return Participation.objects.filter(participating_round=self,
@@ -2744,11 +2748,11 @@ class SchoolTimeCommitment(models.Model):
             max_length=SENTENCE_LENGTH,
             verbose_name="Term name or term number",
             help_text="If your university uses term names (e.g. Winter 2018 term of your Sophomore year), enter your current term name, year in college, and term year. If your university uses term numbers (e.g. 7th semester), enter the term number.")
-    
+
     start_date = models.DateField(
             verbose_name="Date classes start.",
             help_text="What is the first possible day of classes for all students?<br>If you started this term late (or will start this term late), use the date that classes start for all students, not the late registration date.<br>If students who are in different school years or different semester numbers start classes on different dates, use the first possible date that students in your year or semester start classes.<br>If you do not know when the term will start, use the start date of that term from last year.<br>If you don't see a calendar pop-up, please use the date format YYYY-MM-DD.")
-    
+
     end_date = models.DateField(
             verbose_name="Date all exams end.",
             help_text="This is the date your university advertises for the last possible date of any exam for any student in your semester. Use the last possible exam date, even if your personal exams end sooner. If you don't see a calendar pop-up, please use the date format YYYY-MM-DD.")
@@ -3087,7 +3091,7 @@ class InitialApplicationReview(models.Model):
 #    end_date = models.DateField(
 #            verbose_name="Date all exams end.",
 #            help_text="This is the date your university advertises for the last possible date of any exam for any student in your semester. Use the last possible exam date, even if your personal exams end sooner.")
-    
+
 # --------------------------------------------------------------------------- #
 # end reviewer models
 # --------------------------------------------------------------------------- #

--- a/home/templates/home/round_page.html
+++ b/home/templates/home/round_page.html
@@ -22,20 +22,11 @@
 
 	<p>For the current list of internships, <a href="/apply/project-selection">see the current round page</a></p>
 
-	<p>The timeline for this round is:</p>
-
-	<table class=table>
-		<tr><td>{{ page.specific.landingdue }}</td><td>Most FOSS communities will be listed</td></tr>
-		<tr><td>{{ page.specific.appsopen }}</td><td>Applications open</td></tr>
-		<tr><td>{{ page.specific.lateorgs }}</td><td>Last date for new FOSS community listings</td></tr>
-		<tr><td>{{ page.specific.appsclose }}</td><td>Applications and contributions deadline</td></tr>
-		<tr><td>{{ page.specific.appslate }}</td><td>Deadline for late applications and contributions for specific projects (see below for which projects are accepting late applications)</td></tr>
-		<tr><td>{{ page.specific.appsclose }} to {{ page.specific.internannounce }}</td><td>Applicants are encouraged to continue making contributions for the project they applied for</td></tr>
-		<tr><td>{{ page.specific.internannounce }}</td><td>Accepted interns announced on this page at 4pm UTC</td></tr>
-		<tr><td>{{ page.specific.internstarts }} to {{ page.specific.internends }}</td><td>Internships period</td></tr>
-	</table>
+	{% with current_round=page.specific %}
+	{% include 'home/snippet/round_timeline.html' %}
+	{% endwith %}
 	{% with current_round=page %}
-		{% include 'home/snippet/payment_schedule.html' %}
+	{% include 'home/snippet/payment_schedule.html' %}
 	{% endwith %}
 	{{ page.specific.sponsordetails|richtext }}
 

--- a/home/templates/home/round_page.html
+++ b/home/templates/home/round_page.html
@@ -21,7 +21,7 @@
 	<h1>Outreachy {{ page.specific.internstarts|date:"F Y" }} to {{ page.specific.internends|date:"F Y" }} Internships</h1>
 
 	<p>For the current list of internships, <a href="/apply/project-selection">see the current round page</a></p>
-       
+
 	<p>The timeline for this round is:</p>
 
 	<table class=table>
@@ -42,12 +42,15 @@
 	{% with communities=page.get_approved_communities %}
 	{% if communities %}
 		<h1>Past Participating Communities</h1>
-		{% for community in page.get_approved_communities %}
+		{% for community, projects in page.get_approved_communities_and_projects %}
 			<h4>{{ community.name }}</h4>
 			<p>{{ community.description }}</p>
 			{% if page.has_intern_announcement_deadline_passed %}
 				<p>Learn more on the <a href="{% url 'community-landing' round_slug=page.slug community_slug=community.slug %}">{{ community.name }} community landing page</a>.</p>
 			{% endif %}
+			{% with project_status="closed " current_round=page %}
+				{% include 'home/snippet/projects_for_round_page.html' %}
+			{% endwith %}
 		{% endfor %}
 	{% endif %}
 	{% endwith %}

--- a/home/templates/home/round_page_with_communities.html
+++ b/home/templates/home/round_page_with_communities.html
@@ -29,17 +29,7 @@ Outreachy Internships | Apply | Pick a Project
 
 {% if current_round %}
 	<h1>Outreachy {{ current_round.internstarts|date:"F Y" }} to {{ current_round.internends|date:"F Y" }} Internships</h1>
-	<h2>Timeline</h2>
-	<table class=table>
-		<tr><td>{{ current_round.appsopen }}</td><td>Applicants start making contributions to internship projects</td></tr>
-		<tr><td>{{ current_round.lateorgs }}</td><td>Last date for new mentoring community listings</td></tr>
-		<tr><td>{{ current_round.ProjectsDeadline }}</td><td>Last date for mentors to submit new internship project listings</td></tr>
-		<tr><td>{{ current_round.appsclose }} at 4pm UTC</td><td>Application deadline. Last day to finish any contributions to internship projects. Applications who made a contribution must submit the rest of their project application by this date.</td></tr>
-		<tr><td>{{ current_round.appslate }} at 4pm UTC</td><td>Late application deadline for specific projects (see below for which projects are accepting late applications)</td></tr>
-		<tr><td>{{ current_round.appsclose }} to {{ current_round.internannounce }}</td><td>Applicants are encouraged to continue making contributions</td></tr>
-		<tr><td>{{ current_round.internannounce }}</td><td>Accepted interns announced on <a href"/alums/">the alums page</a> at 4pm UTC</td></tr>
-		<tr><td>{{ current_round.internstarts }} to {{ current_round.internends }}</td><td>Internships period</td></tr>
-	</table>
+	{% include 'home/snippet/round_timeline.html' %}
 	{% include 'home/snippet/payment_schedule.html' %}
 	{{ current_round.sponsordetails|safe }}
 {% else %}
@@ -231,7 +221,7 @@ Outreachy Internships | Apply | Pick a Project
 			<h3>Applications Closed {{ current_round.appslate }} at 4pm UTC</h3>
 		{% endif %}
 	{% endif %}
-	
+
 	{% for community, funded_interns, projects in late_projects %}
 		<h4>{{ community.name }} - {{ funded_interns }} intern{{ funded_interns|pluralize }}</h4>
 		<p>{{ community.description }}</p>
@@ -260,7 +250,7 @@ Outreachy Internships | Apply | Pick a Project
 			<h3>Applications Closed {{ current_round.appsclose }} at 4pm UTC</h3>
 		{% endif %}
 	{% endif %}
-	
+
 	{% for community, funded_interns, projects in ontime_projects %}
 		<h4>{{ community.name }} - {{ funded_interns }} intern{{ funded_interns|pluralize }}</h4>
 		<p>{{ community.description }}</p>

--- a/home/templates/home/snippet/payment_schedule.html
+++ b/home/templates/home/snippet/payment_schedule.html
@@ -1,12 +1,12 @@
 
 <h2>Intern Payment Schedule</h2>
-<table class=table>
-	<tr><td>{{ current_round.internstarts }}</td><td>Internships starts</td></tr>
-	<tr><td>{{ current_round.initialfeedback }}</td><td>Initial feedback due</td></tr>
-	<tr><td>{{ current_round.initial_stipend_payment_deadline }}</td><td>The ${{ current_round.initialpayment }} initial stipend will be issued to interns with successful initial feedback</td></tr>
-	<tr><td>{{ current_round.midfeedback }} </td><td>Mid-point feedback due</td></tr>
-	<tr><td>{{ current_round.midpoint_stipend_payment_deadline }}</td><td>The ${{ current_round.midpayment }} midpoint stipend will be issued to interns with successful mid-point feedback</td></tr>
-	<tr><td>{{ current_round.internends }}</td><td>Internships end</td></tr>
-	<tr><td>{{ current_round.finalfeedback }} </td><td>Final feedback due</td></tr>
-	<tr><td>{{ current_round.final_stipend_payment_deadline }}</td><td>The ${{ current_round.finalpayment }} final stipend will be issued to interns with successful final feedback</td></tr>
+<table class="table">
+	<tr><th width="175">{{ current_round.internstarts }}</th><td>Internships starts</td></tr>
+	<tr><th>{{ current_round.initialfeedback }}</th><td>Initial feedback due</td></tr>
+	<tr><th>{{ current_round.initial_stipend_payment_deadline }}</th><td>The ${{ current_round.initialpayment }} initial stipend will be issued to interns with successful initial feedback</td></tr>
+	<tr><th>{{ current_round.midfeedback }} </th><td>Mid-point feedback due</td></tr>
+	<tr><th>{{ current_round.midpoint_stipend_payment_deadline }}</th><td>The ${{ current_round.midpayment }} midpoint stipend will be issued to interns with successful mid-point feedback</td></tr>
+	<tr><th>{{ current_round.internends }}</th><td>Internships end</td></tr>
+	<tr><th>{{ current_round.finalfeedback }} </th><td>Final feedback due</td></tr>
+	<tr><th>{{ current_round.final_stipend_payment_deadline }}</th><td>The ${{ current_round.finalpayment }} final stipend will be issued to interns with successful final feedback</td></tr>
 </table>

--- a/home/templates/home/snippet/round_timeline.html
+++ b/home/templates/home/snippet/round_timeline.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<h2>Timeline</h2>
+
+<table class="table">
+    {% if current_round.has_application_deadline_passed %}<tr><th>{{ current_round.landingdue }}</th><td>Most FOSS communities will be listed</td></tr>{% endif %}
+    <tr><th width="175">{{ current_round.appsopen }}</th><td>Applicants start making contributions to internship projects</td></tr>
+    <tr><th>{{ current_round.lateorgs }}</th><td>Last date for new mentoring community listings</td></tr>
+    {% if not current_round.has_application_deadline_passed %}<tr><th>{{ current_round.ProjectsDeadline }}</th><td>Last date for mentors to submit new internship project listings</td></tr>{% endif %}
+    <tr><th>{{ current_round.appsclose }}<br> at 4pm UTC</th><td>Application deadline. Last day to finish any contributions to internship projects. Applications who made a contribution must submit the rest of their project application by this date.</td></tr>
+    <tr><th>{{ current_round.appslate }}<br> at 4pm UTC</th><td>Late application deadline for specific projects (see below for which projects are accepting late applications)</td></tr>
+    <tr><th>{{ current_round.appsclose }}<br> to {{ current_round.internannounce }}</th><td>Applicants are encouraged to continue making contributions</td></tr>
+    <tr><th>{{ current_round.internannounce }}</th><td>Accepted interns announced on <a href"/alums/">the alums page</a> at 4pm UTC</td></tr>
+    <tr><th>{{ current_round.internstarts }}<br> to {{ current_round.internends }}</th><td>Internships period</td></tr>
+</table>


### PR DESCRIPTION
A first step in simplifying to fix #277.  I'd also like to do a style pass in a separate PR to break up some of the text (and I think you mentioned a desire for better responsiveness n some areas).

The new snippet/round_timeline.html combines the text from the two different page timeline tables... the tables were similar enough that this made sense to do, but I wasn't sure if the 1-2 differing rows were intentional or not so I just put in a couple if statements.  You can remove them if you'd like the timelines to be totally consistent. :)