### PR TITLE
chore: easier to read contributions

### DIFF
--- a/home/templates/home/project_applicants.html
+++ b/home/templates/home/project_applicants.html
@@ -217,7 +217,7 @@ that timeline, taking into account any time commitments the applicant has.
 		{% for c in applicant_contributions %}
 			<p><i>Contribution #{{ forloop.counter }}: started {{ c.date_started }}{% if c.date_merged %}, merged {{ c.date_merged }}{% else %}. Not accepted or merged.{% endif %}</i></p>
 			<p><a href="{{ c.url }}">{{ c.url }}</a></p>
-			<pre>{{ c.description }}</pre>
+			<blockquote>{{ c.description }}</blockquote>
 			{% if not forloop.last %}
 				<hr>
 			{% endif %}

--- a/outreachyhome/templates/sass/application.scss
+++ b/outreachyhome/templates/sass/application.scss
@@ -66,3 +66,10 @@ body {
 .cc-description {
   font-size: $font-size-sm;
 }
+
+blockquote {
+  margin-left: 1rem;
+  padding-left: 1rem;
+  border-left: 3px solid theme-color();
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
The use of `<pre>` tags for the description of Contributions on Review
Project Applicants page are hard to read. Given that most aplicants
don't format the description the text is placed on a single line with a
horizontal scrolling.

This changes the `<pre>` tag to `<blockquote>` and styles it by adding
the left border in the theme colour. The `<blockquote>` word wraps and
preserves any whitespace and newlines with `white-space: pre-wrap` so
both the pre-formatting readability can be achieved.