### PR TITLE
Update opportunities page

### DIFF
--- a/home/templates/home/opportunities.html
+++ b/home/templates/home/opportunities.html
@@ -125,7 +125,8 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><a href="https://www.igalia.com/coding-experience/">Igalia Coding Experience Program</a></li>
                 <li><a href="https://wiki.linuxfoundation.org/lkmp">Linux Kernel Mentorship Program</a></li>
                 <li><a href="https://people.communitybridge.org/">Community Bridge Mentorship</a> (by Linux Foundation)</li>
-                
+
+                <li><a href="https://fellowship.mlh.io/">MLH Fellowship</a></li>
                 <li><a href="https://www.tweag.io/blog/2020-07-28-os-fellowship/">Tweag Open Source Fellowship</a></li>
                 <li><a href="https://processingfoundation.org/fellowships/">Processing Foundation Fellowship</a></li>
 

--- a/home/templates/home/opportunities.html
+++ b/home/templates/home/opportunities.html
@@ -100,20 +100,26 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="http://www.x.org/wiki/BoardOfDirectors/">X.Org</a>'s board member affiliations  </p></li>
             </ul>
 
-            <h2>More opportunities</h2>
+            
+            <h2>More job boards</h2>
             <ul>
-                <li><p><a href="https://developers.google.com/open-source/gsoc/">Google Summer of Code</a> </p></li>
-                <li><p><a href="http://www.fossjobs.net">FOSS jobs board maintained by Moritz Bartl</a> </p></li>
-                <li><p>Sumana Harihareswara's round-ups of various opportunities on <a href="http://www.harihareswara.net/sumana/2014/03/06/">March 2014</a> </p></li>
-                <li><p><a href="https://www.blacksintechnology.net/jobs-board/">Blacks in Tech jobs board</a> </p></li>
-                <li><p><a href="https://www.pocitjobs.com/">People of Color in Tech jobs board</a> </p></li>
-                <li><p><a href="https://www.womenwhocode.com/jobs/">Women Who Code jobs board</a> </p></li>
-                <li><p><a href="https://careers.aises.org/">American Indian Science and Engineering Society</a> </p></li>
+                <li><a href="http://www.fossjobs.net">FOSS jobs board maintained by Moritz Bartl</a></li>
+                <li><a href="https://www.blacksintechnology.net/jobs-board/">Blacks in Tech jobs board</a></li>
+                <li><a href="https://www.pocitjobs.com/">People of Color in Tech jobs board</a></li>
+                <li><a href="https://www.womenwhocode.com/jobs/">Women Who Code jobs board</a></li>
+                <li><a href="https://careers.aises.org/">American Indian Science and Engineering Society</a></li>
             </ul>
-            The list of <a href="https://openhatch.org/wiki/Opportunities">paid opportunities in FOSS</a> maintained by OpenHatch<br/><br/><a href="http://opensourcediversity.org/">List of Open Source Diversity initiatives</a>.<br/> <p><br/></p>
-        </div>
-</div>
 
+            <h2>Paid opportunities in open source</h2>
+            <ul>
+                <li><a href="https://developers.google.com/open-source/gsoc/">Google Summer of Code</a></li>
+                <li><a href="https://developers.google.com/season-of-docs">Google Season of Docs</a></li>
+                <li><a href="https://railsgirlssummerofcode.org/">Rails Girls Summer of Code</a></li>
+                <li>List of <a href="https://wiki.openhatch.org/wiki/Opportunities">paid opportunities in FOSS</a> maintained by OpenHatch</li>
+                <li><a href="http://opensourcediversity.org/">List of Open Source Diversity initiatives</a></li>
+            </ul>
+        </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/home/templates/home/opportunities.html
+++ b/home/templates/home/opportunities.html
@@ -8,20 +8,23 @@ Outreachy | Opportunities with Sponsors - Outreachy
 
 <div class="container">
     <div class="block-paragraph">
-        <div class="rich-text"><p>Are you looking for a full-time position working on open source? Outreachy's sponsors may have a job opening for you!</p><p>The following organizations and companies that sponsor Outreachy offer their own internships and full-time opportunities. Next to each organization or company is the Outreachy communities that organization sponsors. Please note that organizations may not have job openings related to those communities at this point in time.</p><p>The bottom of the page is links to lists of other tech internship programs that you may be interested in.</p>
+        <div class="rich-text">
+            <h1>Opportunities</h1>
+            <p>Are you looking for a full-time position working on open source? Outreachy's sponsors may have a job opening for you!</p>
+            <p>The following organizations and companies that sponsor Outreachy offer their own internships and full-time opportunities. Next to each organization or company is the Outreachy communities that organization sponsors. Please note that organizations may not have job openings related to those communities at this point in time.</p><p>The bottom of the page is links to lists of other tech internship programs that you may be interested in.</p>
             <h3>40 or more</h3>
             <ul>
                 <li><p><a href="https://www.google.com/about/jobs/search/#j=open%20source">Google</a>  </p></li>
                 <li><p><a href="http://careers.mozilla.org">Mozilla</a>  </p></li>
                 <li><p><a href="http://jobs.redhat.com">Red Hat</a> (Ceph, Gluster, Fedora, Foreman, GNOME, JBoss, Linux kernel, OpenShift, OpenStack, oVirt, QEMU jobs)  </p></li>
             </ul>
-            <p></p>
+
             <h3>20-39</h3>
             <ul>
                 <li><p>Intel <a href="https://01.org/about/jobs">Open Source Technology Center</a> and <a href="http://www.intel.com/jobs">company-wide</a> (Linux kernel, OpenStack, Yocto Project jobs)  </p></li>
                 <li><p><a href="https://wikimediafoundation.org/wiki/Job_openings">Wikimedia</a>  </p></li>
             </ul>
-            <p></p>
+
             <h3>10-19</h3>
             <ul>
                 <li><p><a href="http://jobs.bloomberg.com/search?q=open+source">Bloomberg</a>  </p></li>
@@ -31,7 +34,7 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="https://www.newamerica.org/jobs/">Open Technology Institute</a> (Commotion and M-Lab jobs)  </p></li>
                 <li><p><a href="http://www.openstack.org/community/jobs">OpenStack Foundation</a>  </p></li>
             </ul>
-            <p></p>
+
             <h3>5-9</h3>
             <ul>
                 <li><p><a href="http://www.collabora.com/about/vacancies">Collabora</a> (Linux kernel, QEMU jobs)  </p></li>
@@ -39,7 +42,7 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="http://www.fsf.org/resources/jobs">FOSS jobs board maintained by the Free Software Foundation</a> (MediaGoblin, FSF jobs would appear here)  </p></li>
                 <li><p><a href="http://www.xenproject.org/about/join.html">Xen Project's advisory board</a>  </p></li>
             </ul>
-            <p></p>
+
             <h3>3-4</h3>
             <ul>
                 <li><p><a href="http://cadasta.org/about-us/careers/">Cadasta</a>  </p></li>
@@ -56,7 +59,7 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="https://www.yoctoproject.org/ecosystem">Yocto Project's ecosystem</a>  </p></li>
                 <li><p><a href="https://zulip.org/contribute.html">Zulip page on contributing</a>  </p></li>
             </ul>
-            <p></p>
+
             <h3>2</h3>
             <ul>
                 <li><p><a href="https://www.digitalocean.com/company/careers/">DigitalOcean</a>  </p></li>
@@ -68,7 +71,7 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p>Python Software Foundation's <a href="http://www.python.org/psf/members/#sponsor-members">sponsor members</a> and <a href="http://www.python.org/newjobs/">jobs board</a>   </p></li>
                 <li><p><a href="https://www.torproject.org/about/jobs.html.en">Tor</a> and <a href="https://www.eff.org/about/opportunities">Electronic Frontier Foundation</a>  </p></li>
             </ul>
-            <p></p>
+
             <h3>1</h3>
             <ul>
                 <li><p><a href="http://jobs.akamai.com/search/?q=open+source">Akamai</a>  </p></li>
@@ -96,11 +99,10 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="http://www.videolan.org/contact.html">VideoLAN</a>  </p></li>
                 <li><p><a href="http://www.x.org/wiki/BoardOfDirectors/">X.Org</a>'s board member affiliations  </p></li>
             </ul>
-            <p></p>
+
             <h2>More opportunities</h2>
             <ul>
                 <li><p><a href="https://developers.google.com/open-source/gsoc/">Google Summer of Code</a> </p></li>
-                <li><p><a href="https://www.recurse.com/">The Recurse Center</a> </p></li>
                 <li><p><a href="http://www.fossjobs.net">FOSS jobs board maintained by Moritz Bartl</a> </p></li>
                 <li><p>Sumana Harihareswara's round-ups of various opportunities on <a href="http://www.harihareswara.net/sumana/2014/03/06/">March 2014</a> </p></li>
                 <li><p><a href="https://www.blacksintechnology.net/jobs-board/">Blacks in Tech jobs board</a> </p></li>

--- a/home/templates/home/opportunities.html
+++ b/home/templates/home/opportunities.html
@@ -99,7 +99,6 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="http://www.videolan.org/contact.html">VideoLAN</a>  </p></li>
                 <li><p><a href="http://www.x.org/wiki/BoardOfDirectors/">X.Org</a>'s board member affiliations  </p></li>
             </ul>
-
             
             <h2>More job boards</h2>
             <ul>
@@ -115,8 +114,23 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><a href="https://developers.google.com/open-source/gsoc/">Google Summer of Code</a></li>
                 <li><a href="https://developers.google.com/season-of-docs">Google Season of Docs</a></li>
                 <li><a href="https://railsgirlssummerofcode.org/">Rails Girls Summer of Code</a></li>
+                <li><a href="https://old.dataone.org/internships">DataOne Summer Internship Program</a></li>
+                <li><a href="https://wiki.lfnetworking.org/display/LN/LFN+Mentorship+Program">Linux Foundation Networking Mentorship Program</a></li>
+                <li><a href="https://www.x.org/wiki/XorgEVoC/">X.Org Endless Vacation of Code (EVoC)</a></li>
+                <li><a href="https://www.openmainframeproject.org/projects/mentorship-program">Open Mainframe Project Mentorship Program</a></li>
+                <li><a href="https://summerofcode.be/">Open Summer of Code</a> ─ For Belgian students</li>
+                <li><a href="https://fossasia.org/internship">FOSSASIA Internship Program</a></li>
+                <li><a href="https://wiki.hyperledger.org/display/INTERN/Hyperledger+Mentorship+Program">Hyperledger Mentorship Program</a></li>
+                <li><a href="https://www.redox-os.org/rsoc/">Redox Summer of Code</a></li>
+                <li><a href="https://www.igalia.com/coding-experience/">Igalia Coding Experience Program</a></li>
+                <li><a href="https://wiki.linuxfoundation.org/lkmp">Linux Kernel Mentorship Program</a></li>
+                <li><a href="https://people.communitybridge.org/">Community Bridge Mentorship</a> (by Linux Foundation)</li>
+                
+                <li><a href="https://www.tweag.io/blog/2020-07-28-os-fellowship/">Tweag Open Source Fellowship</a></li>
+                <li><a href="https://processingfoundation.org/fellowships/">Processing Foundation Fellowship</a></li>
+
                 <li>List of <a href="https://wiki.openhatch.org/wiki/Opportunities">paid opportunities in FOSS</a> maintained by OpenHatch</li>
-                <li><a href="http://opensourcediversity.org/">List of Open Source Diversity initiatives</a></li>
+                <li>List of <a href="http://opensourcediversity.org/">Open Source Diversity initiatives</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
## Fixes #393

Hi, I took the time to check the opportunities page and made the changes required on issue #393:

- [x] Remove the entry for Recurse Center (they're not completely open source focused, although recursers could study open source if they want)
- [x] Split the Outreachy "More opportunities" section into "More job boards" and "Paid opportunities in open source"
- [x] Categorize all entries under the old "More opportunities" section as a paid opportunity or a job board
- [x] Move all entries from @tapaswenipathak's "SOC-program" section to the new "Paid opportunities in open source" section but only if the opportunity pays a stipend, and the program is still running
- [x] Done!

Let me know if this works for you!