### PR TITLE
Moves blog prompts from bi-weekly emails to the internship docs

### DIFF
--- a/home/templates/home/docs/internship_guide.html
+++ b/home/templates/home/docs/internship_guide.html
@@ -130,12 +130,12 @@ Internship Guide | Outreachy Documentation
 	{% with current_round=applicant_round %}
 		<table class="table">
 			<tr><th width="175">{{ current_round.internship_week_1_email_date }}</th><td>Blog prompt: <a href="#blog-week-1">"Introduce yourself"<a/></td></tr>
-			<tr><th>{{ current_round.internship_week_3_email_date }}</th><td>Blog prompt: "Everybody struggles"</td></tr>
-			<tr><th>{{ current_round.internship_week_5_email_date }}</th><td>Blog prompt: "Think about your audience"</td></tr>
-			<tr><th>{{ current_round.internship_week_7_email_date }}</th><td>Mid-point project progress blog post</td></tr>
-			<tr><th>{{ current_round.internship_week_9_email_date }}</th><td>Blog prompt: "Career opportunities"</td></tr>
+			<tr><th>{{ current_round.internship_week_3_email_date }}</th><td>Blog prompt: <a href="#blog-week-3">"Everybody struggles"</a></td></tr>
+			<tr><th>{{ current_round.internship_week_5_email_date }}</th><td>Blog prompt: <a href="#blog-week-5">"Think about your audience"</a></td></tr>
+			<tr><th>{{ current_round.internship_week_7_email_date }}</th><td><a href="#blog-week-7">Mid-point project progress report</a></td></tr>
+			<tr><th>{{ current_round.internship_week_9_email_date }}</th><td>Blog prompt: <a href="#blog-week-9">"Career opportunities"</a></td></tr>
 			<tr><th>{{ current_round.internship_week_11_email_date }}</th><td>No blog post - interns work on their resume</td></tr>
-			<tr><th>{{ current_round.internship_week_13_email_date }}</th><td>Final project progress blog post</td></tr>
+			<tr><th>{{ current_round.internship_week_13_email_date }}</th><td><a href="#blog-week-13">Final project progress report</a></td></tr>
 		</table>
 	{% endwith %}
 {% endif %}
@@ -144,12 +144,12 @@ Internship Guide | Outreachy Documentation
 	{% with current_round=intern_round %}
 		<table class="table">
 			<tr><th width="175">{{ current_round.internship_week_1_email_date }}</th><td>Blog prompt: <a href="#blog-week-1">"Introduce yourself"</a></td></tr>
-			<tr><th>{{ current_round.internship_week_3_email_date }}</th><td>Blog prompt: "Everybody struggles"</td></tr>
-			<tr><th>{{ current_round.internship_week_5_email_date }}</th><td>Blog prompt: "Think about your audience"</td></tr>
-			<tr><th>{{ current_round.internship_week_7_email_date }}</th><td>Mid-point project progress blog post</td></tr>
-			<tr><th>{{ current_round.internship_week_9_email_date }}</th><td>Blog prompt: "Career opportunities"</td></tr>
+			<tr><th>{{ current_round.internship_week_3_email_date }}</th><td>Blog prompt: <a href="#blog-week-3">"Everybody struggles"</a></td></tr>
+			<tr><th>{{ current_round.internship_week_5_email_date }}</th><td>Blog prompt: <a href="#blog-week-5">"Think about your audience"</a></td></tr>
+			<tr><th>{{ current_round.internship_week_7_email_date }}</th><td><a href="#blog-week-7">Mid-point project progress report</a></td></tr>
+			<tr><th>{{ current_round.internship_week_9_email_date }}</th><td>Blog prompt: <a href="#blog-week-9">"Career opportunities"</a></td></tr>
 			<tr><th>{{ current_round.internship_week_11_email_date }}</th><td>No blog post - interns work on their resume</td></tr>
-			<tr><th>{{ current_round.internship_week_13_email_date }}</th><td>Final project progress blog post</td></tr>
+			<tr><th>{{ current_round.internship_week_13_email_date }}</th><td><a href="#blog-week-13">Final project progress report</a></td></tr>
 		</table>
 	{% endwith %}
 {% endif %}
@@ -190,6 +190,114 @@ Internship Guide | Outreachy Documentation
 <p>Your values may be very different from Sage's. Maybe you're ambitious, you want to be a leader, and you want to influence others. Or maybe you value security, loyalty, and stability. That's great! You should write about the core values that resonate with you.</p>
 
 <p>Pick 1 to 3 <a href="https://jamesclear.com/core-values">core values</a>. Talk about why they are important to you.</p>
+
+<h3 id="blog-week-3"><a href="#blog-week-3">Blog Week 3: Everybody struggles</a></h3>
+
+<p><b>Blog prompt</b></p>
+<p>In your second internship blog post, you should write a blog post about a time in the last three weeks you were stuck. The audience for this blog post is an Outreachy applicant or intern who stuck, and is hesitant to reach out to get help.</p>
+
+<p>When you model that you (a successful accepted Outreachy intern) get stuck, that helps the next round of Outreachy applicants and interns see that it's okay to get stuck. Everybody struggles!</p>
+
+<p>Here's a few questions to get you started:</p>
+
+<ul>
+	<li>What were you stuck on?</li>
+	<li>Why was it confusing or hard?</li>
+	<li>What did you try that didn't work?</li>
+	<li>Where did you search for help?</li>
+	<li>What resources did you find?</li>
+	<li>Were any of those resources out of date or confusing?</li>
+	<li>Were you hesitant to reach out for help, and if so, why were you hesitant?</li>
+	<li>What happened when you reached out for help?</li>
+	<li>What would you tell someone who is worried about asking for help?</li>
+</ul>
+
+<p>Think about your core values you talked about in your first blog post. Did any of your core values help you overcome your struggles?</p>
+
+<h3 id="blog-week-5"><a href="#blog-week-5">Blog Week 5: Think about your audience</a></h3>
+
+<p><b>Blog prompt</b></p>
+<p>In your third internship blog post, you should explain your project to a newcomer in your community. The audience for this blog post is an Outreachy applicant who is thinking about applying to your community. They have similar basic skills as you, but they've never heard of your community before and have never worked on this type of project before.</p>
+
+<p>Here's a few questions to get you started:</p>
+
+<ul>
+	<li>What kind of people participate in your community?</li>
+	<li>What problem is your community trying to solve?</li>
+	<li>How does your project fit into the larger community?</li>
+	<li>Why would people want to use your project?</li>
+	<li>What makes you most excited to work on your project?</li>
+	<li>What new terms or concepts have you learned in the past month?</li>
+	<li>What was confusing to you about the project?</li>
+</ul>
+
+<h3 id="blog-week-7"><a href="#blog-week-7">Blog Week 7: Mid-point project progress report</a></h3>
+
+<p><b>Blog prompt</b></p>
+<p>In your fourth internship blog post, you should write a progress report of what you've accomplished in the first half of the internship. The blog post should also detail what your modified goals for the second half of the internship is.</p>
+
+<p>Here's a few questions to get you started:</p>
+
+<ul>
+	<li>What was your original internship project timeline?</li>
+	<li>What goals have you met?</li>
+	<li>What have you accomplished in the first half of your internship?</li>
+	<li>What project goals took longer than expected?</li>
+	<li>Why did those project goals take longer than expected?</li>
+	<li>What would you do differently if you were starting the project over?</li>
+	<li>Which original goals needed to be modified?</li>
+	<li>What is your new plan for the second half of the internship?</li>
+</ul>
+
+<h3 id="blog-week-9"><a href="#blog-week-9">Blog Week 9: Career opportunities</a></h3>
+
+<p><b>Blog prompt</b></p>
+<p>In your fifth internship blog post, you should write about what your career goals are. If you aren't looking for a job or internship, you can talk about what volunteer opportunities you'd like to participate in. If you're looking for a opportunity in the future, make sure to include when you'll be available.</p>
+
+<p>Here's a few questions to get you started:</p>
+
+<ul>
+	<li>Are you looking for a job, internship, a grant, a volunteer position, or some type of other opportunity?</li>
+	<li>What types of work would you like to contribute to?</li>
+	<li>What tools or skills do you have that would help you with that work?</li>
+	<li>What tools or skills would you like to learn?</li>
+	<li>What interpersonal skills make you a collaborative team member?</li>
+	<li>What languages do you speak, and at what school grade level?</li>
+</ul>
+
+<p>You might also want to talk about how your identity or background will allow you to provide a unique perspective on a team. Companies often want a diverse set of perspectives in their teams. A team with people who have all the same background makes products that don't fit everyone's needs. Please only share what you're comfortable with being public on the internet!</p>
+
+<p>If you're looking for a job opportunity, here's some additional things you might want to mention:</p>
+
+<ul>
+	<li>When are you available to start work? (This should be after your Outreachy internship ends, including if you have an extension.)</li>
+	<li>Are you able to move, and if so, which countries/regions are you willing to move to?</li>
+	<li>Are you looking for a remote job? (Hint, saying you already have three months experience as a remote intern will help you find another remote position!)</li>
+	<li>Are you looking for a full-time or part-time paid position?</li>
+	<li>Are you open to being a self-employed contractor?</li>
+</ul>
+
+<h3 id="blog-week-13"><a href="#blog-week-13">Final project progress report</a></h3>
+
+<p><b>Blog prompt</b></p>
+<p>In your last internship blog post, you should write about how the Outreachy internship has been for you.</p>
+
+<p>Here's a few questions to get you started:</p>
+
+<ul>
+	<li>What was one fear you had about the internship that turned out to not come true?</li>
+	<li>What was one amazing thing that happened during the internship?</li>
+	<li>How did your Outreachy internship help you grow your skills?</li>
+	<li>How did your Outreachy mentor help you along the way?</li>
+	<li>How did Outreachy help you feel more confident in making open source and free software contributions?</li>
+	<li>What communication skills have you learned during the internship?</li>
+	<li>What technical skills have you learned during the internship?</li>
+	<li>What parts of your project did you complete?</li>
+	<li>What are the next steps for you (or someone else) to complete the project?</li>
+</ul>
+
+<p>Think about your core values you talked about in your first blog post. Did any of your core values help you during your internship?
+</p>
 
 <p><a href='#toc'><u>↑ table of contents</u></a></p>
 <hr>

--- a/home/templates/home/email/internship-week-13.txt
+++ b/home/templates/home/email/internship-week-13.txt
@@ -54,21 +54,9 @@ Week 13 goals:
 Week 13 Blog
 ------------
 
-For this week's blog post, we'd like you to write about how the Outreachy internship has been for you.
+The last blog topic is a final project progress report. Please read the blog prompt instructions:
 
-Here's some prompts that could get you started writing this blog post:
-
- - What was one fear you had about the internship that turned out to not come true?
- - What was one amazing thing that happened during the internship?
- - How did your Outreachy internship help you grow your skills?
- - How did your Outreachy mentor help you along the way?
- - How did Outreachy help you feel more confident in making open source and free software contributions?
- - What communication skills have you learned during the internship?
- - What technical skills have you learned during the internship?
- - What parts of your project did you complete?
- - What are the next steps for you (or someone else) to complete the project?
-
-Think about your core values you talked about in your first blog post. Did any of your core values help you during your internship?
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-internship' %}#blog-week-13
 
 We're so proud of all of you! If you have any questions or feedback for us, please contact the Outreachy organizers organizers@outreachy.org
 

--- a/home/templates/home/email/internship-week-3.txt
+++ b/home/templates/home/email/internship-week-3.txt
@@ -47,23 +47,9 @@ Week 3 goals:
 Week 3 Blog
 -----------
 
-For this week's blog post, we'd like you to write a blog post about a time in the last three weeks you were stuck. The audience for this blog post is an Outreachy applicant or intern who stuck, and is hesitant to reach out to get help.
+The second blog topic is "Everybody struggles". Please read the blog prompt instructions:
 
-When you model that you (a successful accepted Outreachy intern) get stuck, that helps the next round of Outreachy applicants and interns see that it's okay to get stuck. Everybody struggles!
-
-Here's some prompts that could get you started writing this blog post:
-
- - What were you stuck on?
- - Why was it confusing or hard?
- - What did you try that didn't work?
- - Where did you search for help?
- - What resources did you find?
- - Were any of those resources out of date or confusing?
- - Were you hesitant to reach out for help, and if so, why were you hesitant?
- - What happened when you reached out for help?
- - What would you tell someone who is worried about asking for help?
-
-Think about your core values you talked about in your first blog post. Did any of your core values help you overcome your struggles?
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-internship' %}#blog-week-3
 
 Again, if you have any questions, please contact us!
 

--- a/home/templates/home/email/internship-week-5.txt
+++ b/home/templates/home/email/internship-week-5.txt
@@ -61,17 +61,9 @@ Week 5 goals:
 Week 5 Blog
 -----------
 
-For this week's blog post, we'd like you to explain your project to a newcomer in your community. The audience for this blog post is an Outreachy applicant who is thinking about applying to your community. They have similar basic skills as you, but they've never heard of your community before and have never worked on this type of project before.
+The third blog topic is "Think about your audience". Please read the blog prompt instructions:
 
-Here's some prompts that could get you started writing this blog post:
-
- - What kind of people participate in your community?
- - What problem is your community trying to solve?
- - How does your project fit into the larger community?
- - Why would people want to use your project?
- - What makes you most excited to work on your project?
- - What new terms or concepts have you learned in the past month?
- - What was confusing to you about the project?
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-internship' %}#blog-week-5
 
 Again, if you have any questions, please contact us!
 

--- a/home/templates/home/email/internship-week-7.txt
+++ b/home/templates/home/email/internship-week-7.txt
@@ -80,18 +80,9 @@ Week 7 goals:
 Week 7 Blog
 -----------
 
-For this week's blog post, we'd like to write a progress report of what you've accomplished in the first half of the internship. The blog post should also detail what your modified goals for the second half of the internship is.
+The fourth blog topic is a mid-point project progress report. Please read the blog prompt instructions:
 
-Here's some prompts that could get you started writing this blog post:
-
- - What was your original internship project timeline?
- - What goals have you met?
- - What have you accomplished in the first half of your internship?
- - What project goals took longer than expected?
- - Why did those project goals take longer than expected?
- - What would you do differently if you were starting the project over?
- - Which original goals needed to be modified?
- - What is your new plan for the second half of the internship?
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-internship' %}#blog-week-7
 
 If you have any questions, please contact the Outreachy organizers organizers@outreachy.org
 

--- a/home/templates/home/email/internship-week-9.txt
+++ b/home/templates/home/email/internship-week-9.txt
@@ -66,26 +66,9 @@ Week 9 goals:
 Week 9 Blog
 -----------
 
-For this week's blog post, we'd like to write about what your career goals are. If you aren't looking for a job or internship, you can talk about what volunteer opportunities you'd like to participate in. If you're looking for a opportunity in the future, make sure to include when you'll be available.
+The fifth blog topic is "Career opportunities". Please read the blog prompt instructions:
 
-Here's some prompts that could get you started writing this blog post:
-
- - Are you looking for a job, internship, a grant, a volunteer position, or some type of other opportunity?
- - What types of work would you like to contribute to?
- - What tools or skills do you have that would help you with that work?
- - What tools or skills would you like to learn?
- - What interpersonal skills make you a collaborative team member?
- - What languages do you speak, and at what school grade level?
-
-You might also want to talk about how your identity or background will allow you to provide a unique perspective on a team. Companies often want a diverse set of perspectives in their teams. A team with people who have all the same background makes products that don't fit everyone's needs. Please only share what you're comfortable with being public on the internet!
-
-If you're looking for a job opportunity, here's some additional things you might want to mention:
-
- - When are you available to start work? (This should be after your Outreachy internship ends, including if you have an extension.)
- - Are you able to move, and if so, which countries/regions are you willing to move to?
- - Are you looking for a remote job? (Hint, saying you already have three months experience as a remote intern will help you find another remote position!)
- - Are you looking for a full-time or part-time paid position?
- - Are you open to being a self-employed contractor?
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-internship' %}#blog-week-9
 
 If you have any questions, please contact the Outreachy organizers organizers@outreachy.org
 


### PR DESCRIPTION
It took a while but I did it! :tada: 

I tried to follow all steps described on https://github.com/outreachy/website/commit/171c06c533deb080051a8ef8b9050f8e42e6c60a and your writing style from the first blog prompt (describing blog posts as second, third, etc., using "your should write a..."). Thank you for such detailed instructions!

Another thing I did was changing the name of the mid-point and final progress posts to something shorter/more explicit about its goals (it went from "blog post" to "report").

I ran tests locally but I'm not sure if I missed something. Please let me know if I did!