### PR TITLE
Fix OpenHatch paid FOSS opportunities link

### DIFF
--- a/home/templates/home/opportunities.html
+++ b/home/templates/home/opportunities.html
@@ -107,7 +107,7 @@ Outreachy | Opportunities with Sponsors - Outreachy
                 <li><p><a href="https://www.womenwhocode.com/jobs/">Women Who Code jobs board</a> </p></li>
                 <li><p><a href="https://careers.aises.org/">American Indian Science and Engineering Society</a> </p></li>
             </ul>
-            The list of <a href="https://openhatch.org/wiki/Opportunities">paid opportunities in FOSS</a> maintained by OpenHatch<br/><br/><a href="http://opensourcediversity.org/">List of Open Source Diversity initiatives</a>.<br/> <p><br/></p>
+            The list of <a href="https://wiki.openhatch.org/wiki/Opportunities">paid opportunities in FOSS</a> maintained by OpenHatch<br/><br/><a href="http://opensourcediversity.org/">List of Open Source Diversity initiatives</a>.<br/> <p><br/></p>
         </div>
 </div>
 


### PR DESCRIPTION
Replace dead link that leads to 404 "Not Found" page with up-to-date link.