### PR TITLE
update: git clone with ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can run Django locally to test changes to the code, test creating new pages,
 To set up your local development environment, first clone the repository to your local machine:
 
 ```
-git clone https://github.com/outreachy/website.git
+git clone git@github.com:outreachy/website.git
 ```
 
 In order to develop with Python, you'll need the Python 3 development headers, so install them. For example, on Debian or Ubuntu Linux, you can use `apt-get install python3-dev` to install the Python 3 development headers. On other Linux distributions, it may be called `python3-devel` or installed by default with `python` packages.


### PR DESCRIPTION
github.com removed user/password auth :sos:

We can start using the SSH keys!

To create a key in your terminal/git bash:
```
https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent
```

Adding the key:
```
https://github.com/settings/keys
```

Updating the remote origin url (use the ssh url instead of the http url)
```
git remote set-url origin "git@github.com:user/repo"
```