### PR TITLE
Fix typo "funding" instead of "finding"

### DIFF
--- a/home/templates/home/snippet/funding_short_description.html
+++ b/home/templates/home/snippet/funding_short_description.html
@@ -1,6 +1,6 @@
 {% comment %}Point coordinators to resources for finding and pitching to sponsors, once the community guide exists.{% endcomment %}
 
-<p>All communities must find finding for at least one intern ($6,500 USD):</p>
+<p>All communities must find funding for at least one intern ($6,500 USD):</p>
 
 <ul>
 	<li><b>Humanitarian open source communities</b> can apply for funding from <a href="{% url 'docs-community' %}#outreachy-general-fund" %}>Outreachy</a></li>


### PR DESCRIPTION
I think the right word for this phrase is:
All communities must find **funding** for at least ...

I