### PR TITLE
Fix off-by-one applicant free time & days available figures

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -2444,7 +2444,7 @@ class CoordinatorApproval(ApprovalStatus):
 # --------------------------------------------------------------------------- #
 
 def create_time_commitment_calendar(tcs, application_round):
-    application_period_length = (application_round.internends - application_round.internstarts).days + 1
+    application_period_length = (application_round.internends - application_round.internstarts).days
     calendar = [0]*(application_period_length)
     for tc in tcs:
         date = application_round.internstarts


### PR DESCRIPTION
Based on the "Time commitment in application" discussion thread in chat, where Sage reported the off-by-one numbers are a known issue. This can be reproduce with the ready-made [InternshipWeekScenario](https://github.com/outreachy/website#scenario-7-internship-week-n), with week 1.

For coordinators / mentors this appears in two places:

- Looking at individual applicant info, "Applicant has 101% of their time free"
- Looking at the table with all applicants, under "Number of days available", "89 / 88 days"

Screenshots for reference:

![101-outreachy](https://user-images.githubusercontent.com/877585/200689191-b0c55d5f-5271-4794-b22d-867a7eebb17b.png)


![89-88-outreachy](https://user-images.githubusercontent.com/877585/200689168-53a6ecf2-963c-484e-9900-5a635ddc5c6a.png)

---

The calculation of the internship length seems to be inclusive of both the start and end date, without needing the `+ 1`. 

I chose to remove the increment because there are already two other places in the code where the same calculation is made without it:

https://github.com/outreachy/website/blob/d2ced828c12e2807f73063e9f1c89227257998ff/home/views.py#L1994

https://github.com/outreachy/website/blob/d2ced828c12e2807f73063e9f1c89227257998ff/home/models.py#L2840

That second occurrence in particular is what’s used for both calculations that were showing the off-by-one error.