### PR TITLE
Replace wrong link to Internship Guide with the correct one

### DIFF
--- a/home/templates/home/eligibility.html
+++ b/home/templates/home/eligibility.html
@@ -34,7 +34,7 @@ The Applicant Guide includes tips for getting your initial application accepted.
 
 <h2>Internship Guide</h2>
 <p>
-The Outreachy <a href='{% url 'docs-applicant' %}'>Internship Guide</a> includes detailed information about the internship schedule, payment schedule, blogging schedule, and other details.
+The Outreachy <a href='{% url 'docs-internship' %}'>Internship Guide</a> includes detailed information about the internship schedule, payment schedule, blogging schedule, and other details.
 </p>
 
 {% if not current_round.initial_applications_open.has_passed %}


### PR DESCRIPTION
On https://www.outreachy.org/apply/eligibility/ under the Internship Guide section, the link leads to the Applicant Guide rather than the Internship Guide, so I fixed it.