### PR TITLE
Docs/Edit: Added an extra section to explain applicants inability to define a Project for themselves. 

### DIFF
--- a/home/templates/home/docs/community_guide.html
+++ b/home/templates/home/docs/community_guide.html
@@ -72,6 +72,7 @@ Community Guide | Outreachy Documentation
 			<li><a href='#project-definition'>Deciding on a project</a></li>
 			<li><a href='#project-forms'>Project description</a></li>
 			<li><a href='#number-of-projects'>Number of projects</a></li>
+			<li><a href='#applicants-inability-to-define-projects'>Applicants Can't Define Their Projects</a></li>
 		</ul>
 	</li>
 	<li><a href='#contribution-period-tasks'>Contribution period tasks</a>
@@ -544,6 +545,13 @@ Mentors will be granted read access to applications for their project and will b
 
 <p>Therefore, it is encouraged for open source / open science communities to list more projects than they have internship funding (or mentors) for. For example, communities that intend to accept 1-2 interns often list 3-5 projects.</p>
 
+<h3 id="applicants-inability-to-define-projects"><a href='#applicants-inability-to-define-projects'>7.4 Applicants Can't Define Their Projects</a></h3>
+
+<p>Outreachy does not allow applicants to define the projects they work on. Outreachy mentors must list all intern projects before the mentor project submission deadline. We do this because many Outreachy applicants don't have experience with open source. People who are new to open source are less likely to know a mentor or be able to come up with a project on their own.</p>
+
+<p>We create a more level playing field by listing all possible projects and how to contact the mentor. We do not allow mentors to add projects for applicants after the project submission deadline. We cannot allow mentors to accept applicants who want to define their own projects. To add a project at the last minute means that other applicants didn't have the chance to apply for it.</p>
+
+<p>It's possible that another applicant would have been a better fit for the project than the person who proposed the custom project. In order to ensure all applicants have a fair chance to apply, we do not allow applicants to define their own projects.</p>
 
 <p><a href='#toc'><u>↑ table of contents</u></a></p>
 <hr>


### PR DESCRIPTION
This PR fixes issue #361.

It adds an extra section to the table of contents at number 7 and explains why applicants aren't allowed to define a project for themselves.  

@sagesharp 