### PR TITLE
Issue-555: Replace Github lab Link with Github Skills Link

### DIFF
--- a/home/templates/home/docs/applicant_guide.html
+++ b/home/templates/home/docs/applicant_guide.html
@@ -293,7 +293,7 @@ The Outreachy website <a href="{% url 'account' %}">account preferences</a> will
 <ul>
 	<li><a href="https://opensource.com/resources/what-open-source">"What is open source?"</a> an article by opensource.com</li>
 	<li><a href="https://pragprog.com/book/vbopens/forge-your-future-with-open-source">"Forge Your Future With Open Source"</a> an introductory book for open source newcomers</li>
-	<li><a href="https://lab.github.com/">GitHub Lab</a> a free resource for learning git</li>
+	<li><a href="https://skills.github.com/">GitHub Skills</a> a free resource for learning how to use Github</li>
 	<li><a href="https://www.freecodecamp.org/">FreeCodeCamp</a> a free resource for learning programming skills</li>
 	<li><a href="https://up-for-grabs.net">Up for Grabs</a> (unaffiliated with Outreachy) - find projects to volunteer your time with</li>
 </ul>


### PR DESCRIPTION
Fixes #555 

Replaced broken Github Lab link with Github Skills link