### PR TITLE
Fix finding/funding typo

### DIFF
--- a/home/templates/home/snippet/funding_short_description.html
+++ b/home/templates/home/snippet/funding_short_description.html
@@ -1,7 +1,7 @@
 {% load humanize %}
 {% comment %}Point coordinators to resources for finding and pitching to sponsors, once the community guide exists.{% endcomment %}
 
-<p>All communities must find finding for at least one intern (${{ current_round.sponsorship_per_intern|intcomma }} USD):</p>
+<p>All communities must find funding for at least one intern (${{ current_round.sponsorship_per_intern|intcomma }} USD):</p>
 
 <ul>
 	<li><b>Humanitarian open source communities</b> can apply for funding from <a href="{% url 'docs-community' %}#outreachy-general-fund" %}>Outreachy</a></li>

--- a/home/test_community_signup.py
+++ b/home/test_community_signup.py
@@ -318,7 +318,7 @@ class ProjectSubmissionTestCase(TestCase):
                 'round_slug': current_round.slug,
                 'community_slug': scenario.participation.community.slug,
         }))
-        self.assertContains(response, '<p>All communities must find finding for at least one intern ($10,000 USD):</p>', html=True)
+        self.assertContains(response, '<p>All communities must find funding for at least one intern ($10,000 USD):</p>', html=True)
         self.assertContains(response, '<div class="card-footer bg-white">Sponsorship for each intern is $10,000 USD.</div>', html=True)
                         
         response = self.coordinator_signs_up_community_to_participate(

--- a/home/test_docs_community.py
+++ b/home/test_docs_community.py
@@ -21,7 +21,7 @@ class CommunityDocsTestCase(TestCase):
         
         response = self.client.get(reverse('docs-community'))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<p>All communities must find finding for at least one intern ($5,000 USD):</p>', html=True)
+        self.assertContains(response, '<p>All communities must find funding for at least one intern ($5,000 USD):</p>', html=True)
         self.assertContains(response, '<p><b>Other communities</b> must secure their own funding for at least one intern ($5,000 USD). After that external funding is secured, they can apply for additional interns to be funded by the Outreachy general fund.</p>', html=True)
         self.assertContains(response, '<p>The sponsorship for each Outreachy intern is $5,000 USD.</p>', html=True)
 
@@ -30,7 +30,7 @@ class CommunityDocsTestCase(TestCase):
 
         response = self.client.get(reverse('docs-community'))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '<p>All communities must find finding for at least one intern ($10,000 USD):</p>', html=True)
+        self.assertContains(response, '<p>All communities must find funding for at least one intern ($10,000 USD):</p>', html=True)
         self.assertContains(response, '<p><b>Other communities</b> must secure their own funding for at least one intern ($10,000 USD). After that external funding is secured, they can apply for additional interns to be funded by the Outreachy general fund.</p>', html=True)
         self.assertContains(response, '<p>The sponsorship for each Outreachy intern is $10,000 USD.</p>', html=True)
 


### PR DESCRIPTION
It looks like the finding/funding typo appears not just on the website but also in some tests.