### PR TITLE
Add mentor blog links to community guide

### DIFF
--- a/home/templates/home/docs/community_guide.html
+++ b/home/templates/home/docs/community_guide.html
@@ -56,13 +56,9 @@ Community Guide | Outreachy Documentation
 	</li>
 	<li><a href='#outreachy-schedule'>Outreachy schedule</a>
 		<ul>
-			<li><a href='#cfp-period'>Communities and projects sign up period</a></li>
-			<li><a href="#initial-application-period">Initial application period</a></li>
-			<li><a href="#contribution-period">Contribution period</a></li>
-			<li><a href='#final-application'>Final application</a></li>
-			<li><a href="#intern-selection-period">Intern selection period</a></li>
-			<li><a href='#intern-announcement'>Intern announcement</a><br>
-				<li><a href="#internship-period">Internship period</a></li>
+			<li><a href='#general-timeline'>General timeline</a></li>
+      <li><a href="#current-timeline">Current internship round schedule</a></li>
+      <li><a href="#timeline-details">Timeline details</a></li>
 		</ul>
 	</li>
 	<li><a href="#community-sign-up-process">Community sign up process</a></li>
@@ -94,7 +90,7 @@ Community Guide | Outreachy Documentation
 		</ul>
 	</li>
 	<li><a href="#estimated-number-of-interns">Estimated number of interns</a></li>
-	<li><a href="#Internship">Internship</a>
+	<li><a href="#internship">Internship</a>
 		<ul>
 			<li><a href='#week-1-expectations'>Week 1 and 2: Expectations for mentors</a></li>
 			<li><a href='#week-5-expectations'>Week 5 and 6: Expectations for mentors</a></li>
@@ -349,7 +345,7 @@ Community Guide | Outreachy Documentation
 
 <p><b>Other communities</b> must secure their own funding for at least one intern (${{ current_round.sponsorship_per_intern|intcomma }} USD). After that external funding is secured, they can apply for additional interns to be funded by the Outreachy general fund.</p>
 
-<h3 id='all-general-funding'><a href='#funding-during-cfp'>3.3.1 Outreachy general fund: All intern funding</a></h3>
+<h3 id='funding-during-cfp'><a href='#funding-during-cfp'>3.3.1 Outreachy general fund: All intern funding</a></h3>
 
 <p>Open science and humanitarian open source communities are invited to apply to the Outreachy general fund when first signing up to participate in Outreachy. If your community is approved, Outreachy will fully fund at least one intern.</p>
 
@@ -520,6 +516,13 @@ Mentors will be granted read access to applications for their project and will b
 
 <p>Outreachy mentors define a project for interns to work on during the three month internship. This is called the "internship project".</p>
 
+<p>Read about the experiences of some of our Outreachy mentors:</p>
+<ul>
+  <li>
+  	<a href="https://yktechtalks.blogspot.com/2023/09/nurturing-talent-and-building-bridges.html" target="_blank">Nurturing Talent and Building Bridges: My Journey as an Outreachy Mentor</a>
+  </li>
+</ul>
+
 <h3 id='project-definition'><a href='#project-definition'>7.1 Deciding on a project</a></h3>
 <p>What makes a good Outreachy internship project? (Credit to QEMU coordinator Stefan Hajnoczi's <a href="https://www.youtube.com/watch?v=xNVCX7YMUL8">talk at KVM Forum</a> for these tips.) A project that is suitable for interns to work on is:</p>
 <ul>
@@ -605,11 +608,12 @@ Mentors will be granted read access to applications for their project and will b
 
 <p>Here are some example lists of newcomer-friendly contribution period tasks:</p>
 <ul>
-	<li><a href="https://code.publiclab.org/">Public Lab newcomer welcome page</a></li>
-	<li><a href="https://zulip.readthedocs.io/en/latest/outreach/apply.html">Zulip contribution period tasks for GSoC and Outreachy applicants</a></li>
-	<li><a href="https://phabricator.wikimedia.org/T317083">Wikimedia contribution period task description</a></li>
-	<li>Oppia pinned a <a href="https://github.com/oppia/oppia/issues/16920">GitHub issue for newcomers</a> and created a <a href="https://github.com/oppia/oppia/wiki">GitHub wiki page for onboarding newcomers</a></li>
-	<li><a href="https://gitlab.com/qemu-project/qemu/-/issues/?sort=created_date&state=opened&label_name%5B%5D=Bite%20Sized&first_page_size=20">QEMU newcomer issues</a></li>
+	<li><a href="https://code.publiclab.org/" target="_blank">Public Lab newcomer welcome page</a></li>
+	<li><a href="https://zulip.readthedocs.io/en/latest/outreach/apply.html" target="_blank">Zulip contribution period tasks for GSoC and Outreachy applicants</a></li>
+	<li><a href="https://phabricator.wikimedia.org/T317083" target="_blank">Wikimedia contribution period task description</a></li>
+	<li>Oppia pinned a <a href="https://github.com/oppia/oppia/issues/16920" target="_blank">GitHub issue for newcomers</a> and created a <a href="https://github.com/oppia/oppia/wiki" target="_blank">GitHub wiki page for onboarding newcomers</a></li>
+	<li><a href="https://gitlab.com/qemu-project/qemu/-/issues/?sort=created_date&state=opened&label_name%5B%5D=Bite%20Sized&first_page_size=20" target="_blank">QEMU newcomer issues</a></li>
+	<li><a href="https://blog.jwf.io/2024/03/win-win-for-all-outreachy/" target="_blank">Designing contribution tasks: Fedora's approach to a marketing project</a></li>
 </ul>
 <h3 id='small-contribution-period-tasks'><a href='#small-contribution-period-tasks'>8.3 Small contribution period tasks</a></h3>
 

--- a/home/templates/home/docs/community_guide.html
+++ b/home/templates/home/docs/community_guide.html
@@ -57,8 +57,8 @@ Community Guide | Outreachy Documentation
 	<li><a href='#outreachy-schedule'>Outreachy schedule</a>
 		<ul>
 			<li><a href='#general-timeline'>General timeline</a></li>
-      <li><a href="#current-timeline">Current internship round schedule</a></li>
-      <li><a href="#timeline-details">Timeline details</a></li>
+			<li><a href="#current-timeline">Current internship round schedule</a></li>
+			<li><a href="#timeline-details">Timeline details</a></li>
 		</ul>
 	</li>
 	<li><a href="#community-sign-up-process">Community sign up process</a></li>


### PR DESCRIPTION
### Work Done

- Fixed broken links in table of contents
- Added `target="_blank"` attribute for external links to open in new tab.
- Added links to mentor blog posts in community guide docs.

[Nurturing talent and building bridges](https://yktechtalks.blogspot.com/2023/09/nurturing-talent-and-building-bridges.html)
[Win-win for all - How to run a non-engineering Outreachy internship](https://blog.jwf.io/2024/03/win-win-for-all-outreachy/)

Closes #573 

