### PR TITLE
Applicants documentation: Add milestones to project timeline

### DIFF
--- a/home/templates/home/docs/applicant_guide.html
+++ b/home/templates/home/docs/applicant_guide.html
@@ -661,6 +661,8 @@ On the page with project details, you should see a link to
 		Carefully review the project description to familiarize yourself with the provided tasks and milestones. Once you have a clear understanding of the project, create a timeline outlining the tasks you plan to work on during the internship. Some interns have found it helpful to break down their project tasks by weeks.
 		Be prepared to adjust your timeline as needed to accommodate unexpected developments or changes in project scope. Make sure to take into account any time commitments you have during the Outreachy internship round.
 		If you are still working on your contributions and need more time, you can leave this blank and edit your application later.
+        In addition to your project timeline, plan to incorporate milestones where you share drafts of your work with your mentors and the community.
+        These milestones should occur at least every two weeks. This will not only help you stay on track but also help you get valuable feedback about your project.
 	</li>
 </ul>
 

--- a/home/templates/home/email/contributors-deadline-reminder.txt
+++ b/home/templates/home/email/contributors-deadline-reminder.txt
@@ -101,7 +101,11 @@ You can edit your final application(s) until {{ current_round.contributions_clos
 
 {{ request.scheme }}://{{ request.get_host }}{% url 'dashboard' %}
 
-The final application will ask you to fill out a timeline for the internship project. If you have trouble with this, or a mentor isn't responsive to your questions about the timeline, do the best you can. You should submit a final application by the final application deadline, even if you feel the timeline isn't complete or perfect.
+The final application will ask you to fill out a timeline for the internship project. For guidance on how to prepare your project timeline, please refer to our documentation.
+
+{{ request.scheme }}://{{ request.get_host }}{% url 'docs-applicant' %}#final-application
+
+If you still have trouble with this, or a mentor isn't responsive to your questions about the timeline, do the best you can. You should submit a final application by the final application deadline, even if you feel the timeline isn't complete or perfect.
 
 {% if role.projects_contributed_to %}Your Project Contributions
 --------------------------

--- a/home/templates/home/email/contributors-deadline-reminder.txt
+++ b/home/templates/home/email/contributors-deadline-reminder.txt
@@ -105,7 +105,7 @@ The final application will ask you to fill out a timeline for the internship pro
 
 {{ request.scheme }}://{{ request.get_host }}{% url 'docs-applicant' %}#final-application
 
-If you still have trouble with this, or a mentor isn't responsive to your questions about the timeline, do the best you can. You should submit a final application by the final application deadline, even if you feel the timeline isn't complete or perfect.
+Your project timeline doesn't need to be perfect, but it should be flexible enough to accommodate any changes in plans and time commitments, or unexpected blockers. Please submit your final application even if your project timeline isn't complete — if you're selected as an intern, you will have the chance to review it alongside your mentors.
 
 {% if role.projects_contributed_to %}Your Project Contributions
 --------------------------


### PR DESCRIPTION
This PR is a follow-up to #578 which includes the addition of milestones to the project timeline

Fixes #572

<img width="1120" alt="Screenshot of the applicant docs about project timeline" src="https://github.com/user-attachments/assets/95df1532-906a-4d13-912f-2f064788cef3">
