### PR TITLE
Fix: Week 9 assignment email template now uses intended Week 10 variables

### DIFF
--- a/home/templates/home/email/internship-week-9.txt
+++ b/home/templates/home/email/internship-week-9.txt
@@ -31,9 +31,9 @@ We also have a list of people who have volunteered to chat with interns! They ar
 Week 9 Mentor & Intern Chat
 ----------------------------
 
-On {{ current_round.week_twelve_chat_text_date }} UTC we will host a chat for Outreachy interns, alums, and mentors:
+On {{ current_round.week_ten_chat_text_date }} UTC we will host a chat for Outreachy interns, alums, and mentors:
 
-{{ current_round.week_twelve_interviewing_chat_url }}
+{{ current_round.week_ten_career_chat_url }}
 
 We'll be discussing networking and how to conduct an informal chat. Details are in the Internship Guide:
 


### PR DESCRIPTION
(Note: Variable names for intern chats need a serious revamp; they no longer reflect the scenario they were created in. At this point, they're technical debt.)

Yesterday, February 3, 2025, I noticed that Week 9 and Week 11 email templates used the same chat variables:

• week_twelve_chat_text_date
• week_twelve_interviewing_chat_url

We intended to run our intern chat on informal chats on February 4, 2025; but because of this error in templating, we sent an assignment email to mentors and coordinators telling them that chat is scheduled for February 18, 2025 (intended date for our chat about next steps in free and open source software). My pull request replaces week_twelve variables with week_ten variables in this template.