### PR TITLE
Remove "from __future__" and "coding: utf-8" lines

### DIFF
--- a/contacts/apps.py
+++ b/contacts/apps.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.apps import AppConfig
 
 

--- a/contacts/forms.py
+++ b/contacts/forms.py
@@ -5,7 +5,6 @@ in the From header, and the topic field will be used to generate the
 Subject header.
 
 """
-from __future__ import unicode_literals
 
 from django_contact_form.forms import ContactForm
 from django import forms

--- a/contacts/views.py
+++ b/contacts/views.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from .forms import OutreachyContactForm
 from django_contact_form.views import ContactFormView
 from django.shortcuts import render

--- a/home/models.py
+++ b/home/models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from os import urandom
 from base64 import urlsafe_b64encode
 from collections import Counter

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, unicode_literals
 
 import os
 import sys

--- a/outreachyhome/settings/base.py
+++ b/outreachyhome/settings/base.py
@@ -10,7 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
-from __future__ import absolute_import, unicode_literals
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os

--- a/outreachyhome/settings/dev.py
+++ b/outreachyhome/settings/dev.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from .base import *  # noqa: F401,F403
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/outreachyhome/settings/production.py
+++ b/outreachyhome/settings/production.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from .base import *  # noqa: F401,F403
 
 import os

--- a/outreachyhome/urls.py
+++ b/outreachyhome/urls.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf import settings
 from django.urls import include, re_path
 from django.contrib import admin

--- a/outreachyhome/wsgi.py
+++ b/outreachyhome/wsgi.py
@@ -7,7 +7,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
-from __future__ import absolute_import, unicode_literals
 
 import os
 

--- a/search/views.py
+++ b/search/views.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.shortcuts import render
 


### PR DESCRIPTION
This is super-minor but these `__future__` and `coding` lines are safe to remove on Python 3.