### PR TITLE
Adds detailed guidance sections to assist mentors in providing detailed feedback.

### DIFF
--- a/docs/payments-extensions-terminations.md
+++ b/docs/payments-extensions-terminations.md
@@ -4,7 +4,7 @@ Outreachy organizers view this internship as a fellowship. Our goal is to attrac
 
 ## Payments
 
-Outreachy mentors have to provide feedback on their interns three times during the internship period. On successful feedback, their intern is paid the stipend associated with that feedback check point (e.g. initial stipend, midpoint stipend, or final stipend).
+Outreachy mentors have to provide feedback on their interns four times during the internship period. On successful feedback, their intern is paid the stipend associated with that feedback check point (e.g. initial stipend, midpoint stipend, or final stipend).
 
 Outreachy interns are paid according to the intern payment schedule, unless their internship is extended or their internship contract is terminated. If the internship is extended, the modified feedback and payment schedule will be visible on both the intern and mentor's dashboards.
 

--- a/home/templates/home/feedback1fromintern_form.html
+++ b/home/templates/home/feedback1fromintern_form.html
@@ -7,7 +7,7 @@ Initial internship feedback
 {% block content %}
 <h1>Feedback on Your Internship</h1>
 
-<p>Outreachy organizers collect feedback from interns three times during the Outreachy internship. Please give yourself at least 5 to 15 minutes to complete this form.</p>
+<p>Outreachy organizers collect feedback from interns four times during the Outreachy internship. Please give yourself at least 5 to 15 minutes to complete this form.</p>
 
 <h2>Instructions</h2>
 

--- a/home/templates/home/feedback1frommentor_form.html
+++ b/home/templates/home/feedback1frommentor_form.html
@@ -6,9 +6,9 @@ Initial mentor feedback
 {% endblock %}
 
 {% block content %}
-<h1>Initial feedback on {{ feedback1frommentor.intern_selection.applicant.applicant.public_name }}</h1>
+<h1>Feedback #1 on {{ feedback1frommentor.intern_selection.applicant.applicant.public_name }}</h1>
 
-<p>Outreachy organizers collect intern feedback from mentors three times during the Outreachy internship.</p>
+<p>Outreachy organizers collect intern feedback from mentors four times during the Outreachy internship.</p>
 
 <hr>
 <h2>Instructions</h2>
@@ -59,11 +59,34 @@ Initial mentor feedback
 	{% elif 'What is the average number of hours per week you spend on mentoring' in field.label_tag %}
 		<hr>
 		<h2>4. Mentor support</h2>
-	{% elif 'Please provide a paragraph describing your intern' in field.label_tag %}
+	{% endif %}
+
+  	{% if 'Please provide a paragraph describing your intern' in field.label_tag %}
 		<hr>
 		<h2>5. Intern progress</h2>
-	{% endif %}
-	{% if 'What actions' in field.label_tag %}
+		<div class="form-group card">
+			{{ field.errors }}
+			<div class="card-header">
+				{{ field.label_tag }}
+					<details>
+						<summary class="text-primary mb-3">Show additional guidance</summary>
+						<div class="bg-white p-3">
+							<p>We recognize that this is the first feedback submission and that substantial project work may not yet be completed.
+								Please provide a detailed report of what your intern has been doing. This might include participation in meetings, planning discussions, or research related to their project goals.
+							</p>
+							<p>If available, please include links to any public artifacts your intern has created so far, such as Git commits, pull requests, or documentation.</p>
+							<p>You may also include the planned deliverables for the internship project. These don't have to be final, as we understand project goals can evolve over the course of the internship.</p>
+						</div>
+					</details>
+			</div>
+			<div class="card-body">
+				{{ field }}
+			</div>
+			{% if field.help_text %}
+				<div class="card-footer bg-white">{{ field.help_text }}</div>
+			{% endif %}
+		</div>
+	{% elif 'What actions' in field.label_tag %}
 		<hr>
 		<h2>6. Payments, extensions, or terminations</h2>
 		<h3>Internship Schedule</h3>

--- a/home/templates/home/feedback2fromintern_form.html
+++ b/home/templates/home/feedback2fromintern_form.html
@@ -7,7 +7,7 @@ Midpoint internship feedback
 {% block content %}
 <h1>Feedback on Your Internship</h1>
 
-<p>Outreachy organizers collect feedback from interns three times during the Outreachy internship. Please give yourself at least 5 to 15 minutes to complete this form.</p>
+<p>Outreachy organizers collect feedback from interns four times during the Outreachy internship. Please give yourself at least 5 to 15 minutes to complete this form.</p>
 
 <h2>Instructions</h2>
 

--- a/home/templates/home/feedback2frommentor_form.html
+++ b/home/templates/home/feedback2frommentor_form.html
@@ -6,9 +6,9 @@ Midpoint mentor feedback
 {% endblock %}
 
 {% block content %}
-<h1>Midpoint Feedback on {{ feedback2frommentor.intern_selection.applicant.applicant.public_name }}</h1>
+<h1>Feedback #2 on {{ feedback2frommentor.intern_selection.applicant.applicant.public_name }}</h1>
 
-<p>Outreachy organizers collect intern feedback from mentors three times during the Outreachy internship.</p>
+<p>Outreachy organizers collect intern feedback from mentors four times during the Outreachy internship.</p>
 
 <h2>Instructions</h2>
 

--- a/home/templates/home/feedback3frommentor_form.html
+++ b/home/templates/home/feedback3frommentor_form.html
@@ -6,7 +6,7 @@ Internship feedback #3
 {% endblock %}
 
 {% block content %}
-<h1>Midpoint Feedback on {{ feedback3frommentor.intern_selection.applicant.applicant.public_name }}</h1>
+<h1>Feedback #3 on {{ feedback3frommentor.intern_selection.applicant.applicant.public_name }}</h1>
 
 <p>Outreachy organizers collect intern feedback from mentors four times during the Outreachy internship.</p>
 
@@ -76,7 +76,29 @@ Internship feedback #3
 		<hr>
 		<h2>Intern progress</h2>
 	{% endif %}
-	{% if 'What actions' in field.label_tag %}
+
+	{% if 'Please provide a paragraph describing your intern' in field.label_tag %}
+		<div class="form-group card">
+			{{ field.errors }}
+			<div class="card-header">
+				{{ field.label_tag }}
+					<details>
+						<summary class="text-primary mb-3">Show additional guidance</summary>
+						<div class="bg-white p-3">
+							<p>Please provide a detailed report on your intern’s overall progress. This includes their participation in meetings, planning discussions, or research related to their project goals.</p>
+							<p>Also, include links to any public artifacts your intern has produced, such as Git commits, pull requests, or documentation. These help us understand the scope of your intern's progress so far.</p>
+							<p>You may also include the expected deliverables for the internship project. These don't have to be final, as we understand project goals can evolve over the course of the internship.</p>
+						</div>
+					</details>
+			</div>
+			<div class="card-body">
+				{{ field }}
+			</div>
+			{% if field.help_text %}
+				<div class="card-footer bg-white">{{ field.help_text }}</div>
+			{% endif %}
+		</div>
+	{% elif 'What actions' in field.label_tag %}
 		<hr>
 		<h2>Internship Schedule</h2>
 

--- a/home/templates/home/feedback4frommentor_form.html
+++ b/home/templates/home/feedback4frommentor_form.html
@@ -129,11 +129,13 @@ Internship feedback #4
 				<p>If you are not requesting an internship extension, please provide a report on the outcome of the internship project. Include:</p>
 				<ul>
 					<li>Summary of the project goals completed</li>
+          				<li>Links to publicly accessible artifacts produced during the internship (e.g., code, documentation, reports)</li>
 					<li>Impact the project will have on the open source community</li>
 					<li>What your intern learned during the internship</li>
 				</ul>
 				<p>If you are requesting an internship extension, please provide the following information:</p>
 				<ul>
+          				<li>The reason for the extension request</li>
 					<li>Your intern's communication frequency with you</li>
 					<li>Your intern's progress on their project</li>
 					<li>Information about the intern's interactions with your open source community</li>


### PR DESCRIPTION
This PR adds a help text for Feedback 1 and Feedback 3 forms to set clearer expectations for mentor feedback.

**Changes Made**

- Added a help text which clarifies that public artifacts and detailed summaries should be included in the intern progress section for feedback forms 1 & 3.
- Created a collapsible help text section to add the updated text. This collapsible help text style was chosen to ensure that the form section doesn’t overwhelm mentors with too much information at once.
- Renamed feedback stages for clarity and consistency & updated the feedback cycle counts to four.

**Screenshots:**

Feedback #1:
<img width="1127" alt="a screenshot of the intern progress section in feedback 1 with the help text open" src="https://github.com/user-attachments/assets/86bdda71-d935-418c-85b0-69751c2ba151" />

<img width="1127" alt="a screenshot of the intern progress section in feedback 1 with the help text closes" src="https://github.com/user-attachments/assets/9b372a60-797a-4db7-8098-984946e87db1" />

Feedback #3:

<img width="1127" alt="a screenshot of the intern progress section in feedback 3 with the help text open" src="https://github.com/user-attachments/assets/c84b1d06-027d-412c-97ad-ae81d0efb042" />
