### PR TITLE
Add favicon

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -3320,7 +3320,9 @@ def initial_mentor_feedback_export_view(request, round_slug):
         except Feedback1FromMentor.DoesNotExist:
             continue
     response = JsonResponse(dictionary_list, safe=False)
-    response['Content-Disposition'] = 'attachment; filename="' + round_slug + '-initial-feedback.json"'
+    # Format: YYYY-MM-DD-HH-mm (UTC)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H-%M")
+    response['Content-Disposition'] = 'attachment; filename="' + round_slug + '-initial-feedback-' + timestamp + '.json"'
     return response
 
 @login_required
@@ -3749,7 +3751,9 @@ def feedback_3_export_view(request, round_slug):
         except Feedback3FromMentor.DoesNotExist:
             continue
     response = JsonResponse(dictionary_list, safe=False)
-    response['Content-Disposition'] = 'attachment; filename="' + round_slug + '-midpoint-feedback.json"'
+    # Format: YYYY-MM-DD-HH-mm (UTC)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H-%M")
+    response['Content-Disposition'] = 'attachment; filename="' + round_slug + '-midpoint-feedback-' + timestamp + '.json"'
     return response
 
 @login_required

--- a/outreachyhome/templates/base.html
+++ b/outreachyhome/templates/base.html
@@ -13,6 +13,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="description" content="An internship program that supports diversity in free and open source software." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="{% static 'css/img/logo-no-background.svg' %}">
 
     <!-- Twitter Card data -->
     <meta name="twitter:card" content="summary">


### PR DESCRIPTION
Added a favicon to the website so it displays properly in browser tabs and bookmarks. Previously, the site didn’t have one, which made it harder to quickly recognize when multiple tabs were open.

What I changed
	•	Added a <link rel="icon"> tag inside the <head> section of outreachyhome/templates/base.html.
	•	Reused the existing logo-no-background.svg file to keep things consistent with the current branding and ensure good quality on high-resolution screens.

Why this helps

This small change improves the overall polish of the site and makes it easier for users to identify the Outreachy tab in their browser.

Fixes #619.
