### PR TITLE
✨ feat: Allow coordinators view internship feedback

### DIFF
--- a/home/dashboard.py
+++ b/home/dashboard.py
@@ -1129,6 +1129,24 @@ def unselected_intern(request, today):
     return applicant
 
 
+def coordinator_feedback(request, today):
+    try:
+        current_round = RoundPage.objects.get(
+            internstarts__lte=today,
+            # Keep the section visible for 45 days after the final feedback deadline
+            # so coordinators can still review late or newly-submitted feedback.
+            finalfeedback__gt=today - datetime.timedelta(days=45),
+        )
+        current_round.today = today
+    except RoundPage.DoesNotExist:
+        return None
+
+    if not current_round.is_coordinator(request.user):
+        return None
+
+    return current_round
+
+
 def mentor(request, today):
     return MentorRelationship.objects.filter(mentor__mentor__account=request.user)
 
@@ -1219,6 +1237,7 @@ DASHBOARD_SECTIONS = (
     intern,
     eligibility_prompts,
     unselected_intern,
+    coordinator_feedback,
     mentor,
     mentor_projects,
     approval_status,

--- a/home/templates/home/dashboard/coordinator_feedback.html
+++ b/home/templates/home/dashboard/coordinator_feedback.html
@@ -1,0 +1,19 @@
+{% with current_round=section %}
+<h2>Internship Feedback</h2>
+<p>You can review feedback submitted by mentors and interns in your community for the {{ current_round.official_name }} round.</p>
+<ul>
+	{% if current_round.initialfeedback %}
+		<li><a href="{% url 'initial-feedback-summary' round_slug=current_round.slug %}">Feedback #1 summary</a></li>
+	{% endif %}
+	{% if current_round.midfeedback %}
+		<li><a href="{% url 'midpoint-feedback-summary' round_slug=current_round.slug %}">Feedback #2 summary</a></li>
+	{% endif %}
+	{% if current_round.feedback3_due %}
+		<li><a href="{% url 'feedback-3-summary' round_slug=current_round.slug %}">Feedback #3 summary</a></li>
+	{% endif %}
+	{% if current_round.finalfeedback %}
+		<li><a href="{% url 'final-feedback-summary' round_slug=current_round.slug %}">Feedback #4 summary</a></li>
+	{% endif %}
+</ul>
+<p>Note: intern comments about their mentor are only shown if the intern opted to share them with community coordinators.</p>
+{% endwith %}

--- a/home/templates/home/feedback3.html
+++ b/home/templates/home/feedback3.html
@@ -6,10 +6,8 @@ Feedback #3 for {{ current_round.official_name }}
 {% endblock %}
 
 {% block content %}
-{% if request.user.is_staff %}
-	{% with interns=current_round.get_approved_intern_selections %}
-		{% for i in interns %}
-			<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
+	{% for i in interns %}
+		<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
 
 			{% with mentor_status=i.get_feedback_3_status_from_mentor midpoint_intern_status=i.get_feedback_3_status_from_intern %}
 				{% if mentor_status == i.PAY or mentor_status == i.PAID %}
@@ -517,7 +515,7 @@ Feedback #3 for {{ current_round.official_name }}
 						<td colspan="3"><b>Mentor support</b></td>
 					</tr>
 
-					{% if midpoint_intern_status == i.SUBMITTED %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback3fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}
+					{% if midpoint_intern_status == i.SUBMITTED %}{% if request.user.is_staff or i.feedback3fromintern.share_mentor_feedback_with_community_coordinator %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback3fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}{% endif %}
 
 					{% if i.feedback3frommentor %}<tr><td colspan="3"><p>Mentor's report on mentor support:</p><p>{{ i.feedback3frommentor.mentors_report|linebreaksbr }}</p></td></tr>{% endif %}
 
@@ -545,7 +543,5 @@ Feedback #3 for {{ current_round.official_name }}
 					</tr>
 				{% endwith %}
 			</table>
-		{% endfor %}
-	{% endwith %}
-{% endif %}
+	{% endfor %}
 {% endblock %}

--- a/home/templates/home/feedback4.html
+++ b/home/templates/home/feedback4.html
@@ -6,10 +6,8 @@ Feedback #4 for {{ current_round.official_name }}
 {% endblock %}
 
 {% block content %}
-{% if request.user.is_staff %}
-	{% with interns=current_round.get_approved_intern_selections %}
-		{% for i in interns %}
-			<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
+	{% for i in interns %}
+		<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
 
 			{% with mentor_status=i.get_feedback_4_status_from_mentor intern_status=i.get_feedback_4_status_from_intern %}
 				{% if mentor_status == i.PAY or mentor_status == i.PAID %}
@@ -557,7 +555,7 @@ Feedback #4 for {{ current_round.official_name }}
 						<td colspan="3"><b>Mentor support</b></td>
 					</tr>
 
-					{% if intern_status == i.SUBMITTED %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback4fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}
+					{% if intern_status == i.SUBMITTED %}{% if request.user.is_staff or i.feedback4fromintern.share_mentor_feedback_with_community_coordinator %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback4fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}{% endif %}
 
 					{% if i.feedback4frommentor %}<tr><td colspan="3"><p>Mentor's report on mentor support:</p><p>{{ i.feedback4frommentor.mentors_report|linebreaksbr }}</p></td></tr>{% endif %}
 
@@ -601,7 +599,5 @@ Feedback #4 for {{ current_round.official_name }}
 					</tr>
 				{% endwith %}
 			</table>
-		{% endfor %}
-	{% endwith %}
-{% endif %}
+	{% endfor %}
 {% endblock %}

--- a/home/templates/home/initial_feedback.html
+++ b/home/templates/home/initial_feedback.html
@@ -6,11 +6,9 @@ Initial Feedback for {{ current_round.official_name }}
 {% endblock %}
 
 {% block content %}
-{% if request.user.is_staff %}
-	{% with interns=current_round.get_approved_intern_selections %}
-		{% for i in interns %}
-			<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
-			<hr>
+	{% for i in interns %}
+		<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
+		<hr>
 
 			{% with initial_mentor_status=i.get_mentor_initial_feedback_status initial_intern_status=i.get_intern_initial_feedback_status %}
 				{% if initial_mentor_status == i.PAY or initial_mentor_status == i.PAID %}
@@ -222,7 +220,7 @@ Initial Feedback for {{ current_round.official_name }}
 						<td colspan="3"><b>4. Mentor support</b></td>
 					</tr>
 
-					{% if initial_intern_status == i.SUBMITTED %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback1fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}
+					{% if initial_intern_status == i.SUBMITTED %}{% if request.user.is_staff or i.feedback1fromintern.share_mentor_feedback_with_community_coordinator %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback1fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}{% endif %}
 
 					{% if i.feedback1frommentor %}<tr><td colspan="3"><p>Mentor's report on mentor support:</p><p>{{ i.feedback1frommentor.mentors_report|linebreaksbr }}</p></td></tr>{% endif %}
 
@@ -250,7 +248,5 @@ Initial Feedback for {{ current_round.official_name }}
 					</tr>
 				{% endwith %}
 			</table>
-		{% endfor %}
-	{% endwith %}
-{% endif %}
+	{% endfor %}
 {% endblock %}

--- a/home/templates/home/midpoint_feedback.html
+++ b/home/templates/home/midpoint_feedback.html
@@ -6,10 +6,8 @@ Midpoint Feedback for {{ current_round.official_name }}
 {% endblock %}
 
 {% block content %}
-{% if request.user.is_staff %}
-	{% with interns=current_round.get_approved_intern_selections %}
-		{% for i in interns %}
-			<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
+	{% for i in interns %}
+		<h2>{{ i.community_name }} - {{ i.intern_name }}</h2>
 
 			{% with midpoint_mentor_status=i.get_mentor_midpoint_feedback_status midpoint_intern_status=i.get_intern_midpoint_feedback_status %}
 				{% if midpoint_mentor_status == i.PAY or midpoint_mentor_status == i.PAID %}
@@ -497,7 +495,7 @@ Midpoint Feedback for {{ current_round.official_name }}
 						<td colspan="3"><b>Mentor support</b></td>
 					</tr>
 
-					{% if midpoint_intern_status == i.SUBMITTED %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback2fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}
+					{% if midpoint_intern_status == i.SUBMITTED %}{% if request.user.is_staff or i.feedback2fromintern.share_mentor_feedback_with_community_coordinator %}<tr><td colspan="3"><p>Intern's report on mentor support:</p><p>{{ i.feedback2fromintern.mentor_support|linebreaksbr }}</p></td></tr>{% endif %}{% endif %}
 
 					{% if i.feedback2frommentor %}<tr><td colspan="3"><p>Mentor's report on mentor support:</p><p>{{ i.feedback2frommentor.mentors_report|linebreaksbr }}</p></td></tr>{% endif %}
 
@@ -525,7 +523,5 @@ Midpoint Feedback for {{ current_round.official_name }}
 					</tr>
 				{% endwith %}
 			</table>
-		{% endfor %}
-	{% endwith %}
-{% endif %}
+	{% endfor %}
 {% endblock %}

--- a/home/test_coordinator_feedback.py
+++ b/home/test_coordinator_feedback.py
@@ -1,0 +1,217 @@
+import datetime
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from home import models
+from home import factories
+from home import scenarios
+
+FEEDBACK_SUMMARY_URLS = [
+    'initial-feedback-summary',
+    'midpoint-feedback-summary',
+    'feedback-3-summary',
+    'final-feedback-summary',
+]
+
+def make_feedback1_from_intern(intern_selection, share_with_coordinator=False,
+                                mentor_support='Test mentor support',
+                                progress_report='Test intern progress report'):
+    return models.Feedback1FromIntern.objects.create(
+        intern_selection=intern_selection,
+        allow_edits=False,
+        ip_address='127.0.0.1',
+        last_contact=datetime.date.today(),
+        hours_worked=models.BaseInternFeedback.HOURS_30,
+        mentor_support=mentor_support,
+        share_mentor_feedback_with_community_coordinator=share_with_coordinator,
+        mentor_answers_questions=True,
+        intern_asks_questions=True,
+        mentor_support_when_stuck=True,
+        meets_privately=True,
+        meets_over_phone_or_video_chat=True,
+        intern_missed_meetings=False,
+        talk_about_project_progress=True,
+        blog_created=True,
+        progress_report=progress_report,
+    )
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class FeedbackSummaryAccessTest(TestCase):
+    """Tests access control for the four feedback summary views."""
+
+    def setUp(self):
+        self.scenario = scenarios.InternSelectionScenario(
+            applicant1__applicant__public_name="Applicant 1",
+            applicant2__applicant__public_name="Applicant 2",
+        )
+        self.round_slug = self.scenario.round.slug
+        self.organizer = factories.ComradeFactory()
+        self.organizer.account.is_staff = True
+        self.organizer.account.save()
+
+    def test_login_required(self):
+        """Unauthenticated users are redirected to the login page."""
+        self.client.logout()
+        for url_name in FEEDBACK_SUMMARY_URLS:
+            with self.subTest(url=url_name):
+                response = self.client.get(reverse(url_name, kwargs={'round_slug': self.round_slug}))
+                self.assertEqual(response.status_code, 302)
+                self.assertIn('/login/', response.url)
+
+    def test_non_coordinator_non_staff_denied(self):
+        """Logged-in users who are not staff or a coordinator for this round are denied."""
+        visitors = [
+            ('comrade', factories.ComradeFactory().account),
+            ('applicant', self.scenario.applicant1.applicant.account),
+            ('mentor', self.scenario.mentor.account),
+        ]
+        for url_name in FEEDBACK_SUMMARY_URLS:
+            for visitor_type, account in visitors:
+                with self.subTest(url=url_name, visitor=visitor_type):
+                    self.client.force_login(account)
+                    response = self.client.get(reverse(url_name, kwargs={'round_slug': self.round_slug}))
+                    self.assertEqual(response.status_code, 403)
+
+    def test_staff_can_access_all_feedback_summaries(self):
+        """Outreachy organizers (staff) can access all four feedback summary pages."""
+        self.client.force_login(self.organizer.account)
+        for url_name in FEEDBACK_SUMMARY_URLS:
+            with self.subTest(url=url_name):
+                response = self.client.get(reverse(url_name, kwargs={'round_slug': self.round_slug}))
+                self.assertEqual(response.status_code, 200)
+
+    def test_coordinator_can_access_all_feedback_summaries(self):
+        """Community coordinators can access all four feedback summary pages."""
+        self.client.force_login(self.scenario.coordinator.account)
+        for url_name in FEEDBACK_SUMMARY_URLS:
+            with self.subTest(url=url_name):
+                response = self.client.get(reverse(url_name, kwargs={'round_slug': self.round_slug}))
+                self.assertEqual(response.status_code, 200)
+
+    def test_coordinator_from_other_community_is_denied(self):
+        """A coordinator who is not approved for any community in this round is denied."""
+        other_coordinator = factories.CoordinatorFactory()
+        self.client.force_login(other_coordinator.account)
+        for url_name in FEEDBACK_SUMMARY_URLS:
+            with self.subTest(url=url_name):
+                response = self.client.get(reverse(url_name, kwargs={'round_slug': self.round_slug}))
+                self.assertEqual(response.status_code, 403)
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class FeedbackSummaryCommunityFilterTest(TestCase):
+    """Tests that coordinators only see interns from their own community."""
+
+    def setUp(self):
+        self.scenario = scenarios.InternSelectionScenario(
+            applicant2__applicant__public_name="Community 1 Intern",
+        )
+        self.round_slug = self.scenario.round.slug
+
+        # Create a second approved intern in a different community in the same round.
+        # Pass round= as a Param so InternSelectionFactory reuses the existing round
+        # rather than creating a new one (which would conflict on slug).
+        self.other_intern = factories.InternSelectionFactory(
+            round=self.scenario.round,
+            organizer_approved=True,
+            applicant__applicant__public_name="Community 2 Intern",
+            project__project_round__approval_status=models.ApprovalStatus.APPROVED,
+        )
+
+        self.organizer = factories.ComradeFactory()
+        self.organizer.account.is_staff = True
+        self.organizer.account.save()
+
+    def test_coordinator_sees_only_their_community_interns(self):
+        """
+        A coordinator for community 1 sees only community 1's interns,
+        not interns from community 2 in the same round.
+        """
+        self.client.force_login(self.scenario.coordinator.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Community 1 Intern')
+        self.assertNotContains(response, 'Community 2 Intern')
+
+    def test_staff_sees_interns_from_all_communities(self):
+        """Staff see interns from all communities in the round."""
+        self.client.force_login(self.organizer.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Community 1 Intern')
+        self.assertContains(response, 'Community 2 Intern')
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class FeedbackSummaryContentTest(TestCase):
+    """Tests what coordinators and staff can see in the feedback content."""
+
+    def setUp(self):
+        self.scenario = scenarios.InternSelectionScenario(
+            applicant2__applicant__public_name="Test Intern",
+        )
+        self.round_slug = self.scenario.round.slug
+        self.intern_selection = self.scenario.intern_selection2
+
+        self.organizer = factories.ComradeFactory()
+        self.organizer.account.is_staff = True
+        self.organizer.account.save()
+
+    def test_coordinator_sees_intern_progress_report(self):
+        """Coordinators can see the intern's progress report."""
+        make_feedback1_from_intern(
+            self.intern_selection,
+            progress_report='My project is progressing well.',
+        )
+        self.client.force_login(self.scenario.coordinator.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertContains(response, 'My project is progressing well.')
+
+    def test_staff_sees_intern_progress_report(self):
+        """Staff can see the intern's progress report."""
+        make_feedback1_from_intern(
+            self.intern_selection,
+            progress_report='My project is progressing well.',
+        )
+        self.client.force_login(self.organizer.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertContains(response, 'My project is progressing well.')
+
+    def test_coordinator_sees_mentor_support_when_intern_opted_in(self):
+        """
+        Coordinators see the intern's comments about their mentor
+        when the intern opted to share them with the coordinator.
+        """
+        make_feedback1_from_intern(
+            self.intern_selection,
+            share_with_coordinator=True,
+            mentor_support='My mentor responds quickly.',
+        )
+        self.client.force_login(self.scenario.coordinator.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertContains(response, 'My mentor responds quickly.')
+
+    def test_coordinator_cannot_see_mentor_support_without_opt_in(self):
+        """
+        Coordinators cannot see the intern's comments about their mentor
+        when the intern did not opt to share them with the coordinator.
+        """
+        make_feedback1_from_intern(
+            self.intern_selection,
+            share_with_coordinator=False,
+            mentor_support='Private mentor feedback.',
+        )
+        self.client.force_login(self.scenario.coordinator.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertNotContains(response, 'Private mentor feedback.')
+
+    def test_staff_sees_mentor_support_regardless_of_opt_in(self):
+        """Staff can always see the intern's comments about their mentor."""
+        make_feedback1_from_intern(
+            self.intern_selection,
+            share_with_coordinator=False,
+            mentor_support='Staff-only mentor feedback.',
+        )
+        self.client.force_login(self.organizer.account)
+        response = self.client.get(reverse('initial-feedback-summary', kwargs={'round_slug': self.round_slug}))
+        self.assertContains(response, 'Staff-only mentor feedback.')

--- a/home/test_coordinator_feedback.py
+++ b/home/test_coordinator_feedback.py
@@ -12,9 +12,11 @@ FEEDBACK_SUMMARY_URLS = [
     'final-feedback-summary',
 ]
 
-def make_feedback1_from_intern(intern_selection, share_with_coordinator=False,
-                                mentor_support='Test mentor support',
-                                progress_report='Test intern progress report'):
+def make_feedback1_from_intern(
+    intern_selection, share_with_coordinator=False,
+    mentor_support='Test mentor support',
+    progress_report='Test intern progress report'
+):
     return models.Feedback1FromIntern.objects.create(
         intern_selection=intern_selection,
         allow_edits=False,

--- a/home/views.py
+++ b/home/views.py
@@ -3324,15 +3324,19 @@ def initial_mentor_feedback_export_view(request, round_slug):
     return response
 
 @login_required
-@staff_member_required
 def initial_feedback_summary(request, round_slug):
     current_round = get_object_or_404(RoundPage, slug=round_slug)
-
+    if request.user.is_staff:
+        interns = current_round.get_approved_intern_selections()
+    elif current_round.is_coordinator(request.user):
+        interns = current_round.get_approved_intern_selections().filter(
+            project__project_round__community__coordinatorapproval__coordinator__account=request.user,
+            project__project_round__community__coordinatorapproval__approval_status=ApprovalStatus.APPROVED,
+        )
+    else:
+        raise PermissionDenied("You must be a staff member or community coordinator to view feedback.")
     return render(request, 'home/initial_feedback.html',
-            {
-            'current_round' : current_round,
-            },
-            )
+            {'current_round': current_round, 'interns': interns})
 
 class Feedback2FromMentorUpdate(LoginRequiredMixin, reversion.views.RevisionMixin, UpdateView):
     form_class = modelform_factory(Feedback2FromMentor,
@@ -3528,15 +3532,19 @@ class Feedback2FromInternUpdate(LoginRequiredMixin, reversion.views.RevisionMixi
         return redirect(reverse('dashboard') + '#feedback')
 
 @login_required
-@staff_member_required
 def midpoint_feedback_summary(request, round_slug):
     current_round = get_object_or_404(RoundPage, slug=round_slug)
-
+    if request.user.is_staff:
+        interns = current_round.get_approved_intern_selections()
+    elif current_round.is_coordinator(request.user):
+        interns = current_round.get_approved_intern_selections().filter(
+            project__project_round__community__coordinatorapproval__coordinator__account=request.user,
+            project__project_round__community__coordinatorapproval__approval_status=ApprovalStatus.APPROVED,
+        )
+    else:
+        raise PermissionDenied("You must be a staff member or community coordinator to view feedback.")
     return render(request, 'home/midpoint_feedback.html',
-            {
-            'current_round' : current_round,
-            },
-            )
+            {'current_round': current_round, 'interns': interns})
 
 class Feedback3FromMentorUpdate(LoginRequiredMixin, reversion.views.RevisionMixin, UpdateView):
     form_class = modelform_factory(Feedback3FromMentor,
@@ -3753,15 +3761,19 @@ def feedback_3_export_view(request, round_slug):
     return response
 
 @login_required
-@staff_member_required
 def feedback_3_summary(request, round_slug):
     current_round = get_object_or_404(RoundPage, slug=round_slug)
-
+    if request.user.is_staff:
+        interns = current_round.get_approved_intern_selections()
+    elif current_round.is_coordinator(request.user):
+        interns = current_round.get_approved_intern_selections().filter(
+            project__project_round__community__coordinatorapproval__coordinator__account=request.user,
+            project__project_round__community__coordinatorapproval__approval_status=ApprovalStatus.APPROVED,
+        )
+    else:
+        raise PermissionDenied("You must be a staff member or community coordinator to view feedback.")
     return render(request, 'home/feedback3.html',
-            {
-            'current_round' : current_round,
-            },
-            )
+            {'current_round': current_round, 'interns': interns})
 
 class Feedback4FromMentorUpdate(LoginRequiredMixin, reversion.views.RevisionMixin, UpdateView):
     form_class = modelform_factory(Feedback4FromMentor,
@@ -3988,15 +4000,19 @@ class Feedback4FromInternUpdate(LoginRequiredMixin, reversion.views.RevisionMixi
         return redirect(reverse('dashboard') + '#feedback')
 
 @login_required
-@staff_member_required
 def feedback_4_summary(request, round_slug):
     current_round = get_object_or_404(RoundPage, slug=round_slug)
-
+    if request.user.is_staff:
+        interns = current_round.get_approved_intern_selections()
+    elif current_round.is_coordinator(request.user):
+        interns = current_round.get_approved_intern_selections().filter(
+            project__project_round__community__coordinatorapproval__coordinator__account=request.user,
+            project__project_round__community__coordinatorapproval__approval_status=ApprovalStatus.APPROVED,
+        )
+    else:
+        raise PermissionDenied("You must be a staff member or community coordinator to view feedback.")
     return render(request, 'home/feedback4.html',
-            {
-            'current_round' : current_round,
-            },
-            )
+            {'current_round': current_round, 'interns': interns})
 
 @login_required
 @staff_member_required


### PR DESCRIPTION
Previously, the four internship feedback summary pages were restricted to Outreachy organizers only. Community coordinators had no visibility into feedback for interns in their own community.

This PR grants approved community coordinators access to all four feedback summary pages, filtered to show only interns from their own community. Staff continue to see all interns across all communities.

The intern's comments about their mentor (`mentor_support`) are only shown to coordinators if the intern opted in to share them. Staff can always see this field regardless. The intern's progress report is visible to both coordinators and staff.

A new dashboard section is added for coordinators during active internship rounds, with links to whichever feedback pages are currently available.

Tests have also been added to cover these changes.